### PR TITLE
ResourceManager does not alter files anymore when adding resources.

### DIFF
--- a/helpers/class.ResourceManager.php
+++ b/helpers/class.ResourceManager.php
@@ -123,8 +123,9 @@ class taoItems_helpers_ResourceManager implements MediaBrowser, MediaManagement
      */
     public function add($source, $fileName, $parent)
     {
-
-        $fileName = tao_helpers_File::getSafeFileName($fileName);
+        if (!\tao_helpers_File::securityCheck($fileName, true)) {
+            throw new \common_Exception('Unsecured filename "'.$fileName.'"');
+        }         
 
         $sysPath = $this->getSysPath($parent.$fileName);
 


### PR DESCRIPTION
This prevent orphan files to be inserted in items if they contain special character in their name.