### PR TITLE
remove leading slash in baseUrl concat

### DIFF
--- a/views/js/assets/strategies.js
+++ b/views/js/assets/strategies.js
@@ -42,12 +42,14 @@ define([
             handle : function handleBaseUrl(url, data){
                 if(typeof data.baseUrl === 'string' && (urlUtil.isRelative(url)) ){
 
+                    console.log(url + '');
+
                     //is slashcat we manage slash concact
                     if(data.slashcat === true){
                         return data.baseUrl.replace(/\/$/, '') + '/' + url.toString().replace(/^\.\//, '').replace(/^\//, '');
                     }
 
-                    return data.baseUrl + url.toString();
+                    return data.baseUrl + url.toString().replace(/^\.?\//, '');
                 }
             }
         },

--- a/views/js/assets/strategies.js
+++ b/views/js/assets/strategies.js
@@ -42,8 +42,6 @@ define([
             handle : function handleBaseUrl(url, data){
                 if(typeof data.baseUrl === 'string' && (urlUtil.isRelative(url)) ){
 
-                    console.log(url + '');
-
                     //is slashcat we manage slash concact
                     if(data.slashcat === true){
                         return data.baseUrl.replace(/\/$/, '') + '/' + url.toString().replace(/^\.\//, '').replace(/^\//, '');


### PR DESCRIPTION
When resolving assets using a `baseUrl` (`getFile` and co.), the leading `/` and `./` or trimmed. 