### PR TITLE
fix test with leading slash removed

### DIFF
--- a/views/js/test/assets/strategies/test.js
+++ b/views/js/test/assets/strategies/test.js
@@ -54,7 +54,7 @@ define([
         title    : 'relative URL current directory',
         baseUrl  : 'http://tao.localdomain?path=',
         url      : './test/test.html',
-        resolved : 'http://tao.localdomain?path=./test/test.html'
+        resolved : 'http://tao.localdomain?path=test/test.html'
     }];
 
     QUnit


### PR DESCRIPTION
Make the test to reflect changes made in asset resolving (leading `./` is removed from relative paths)