### PR TITLE
Fixed missed use call for common_exception_Error

### DIFF
--- a/models/classes/media/LocalItemSource.php
+++ b/models/classes/media/LocalItemSource.php
@@ -20,6 +20,7 @@
  */
 namespace oat\taoItems\model\media;
 
+use common_exception_Error;
 use oat\tao\model\media\MediaManagement;
 use tao_helpers_File;
 use taoItems_models_classes_ItemsService;


### PR DESCRIPTION
Run import and got `PHP Fatal error:  Class 'oat\taoItems\model\media\common_exception_Error' not found in /home/vagrant/Code/tao3.0/taoItems/models/classes/media/LocalItemSource.php on line 147`