### PR TITLE
Feature/tao 3725 item css no cache strategy

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '2.25.1',
+    'version' => '2.26.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoBackOffice' => '>=0.8',

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -138,6 +138,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater {
             OntologyUpdater::syncModels();
             $this->setVersion('2.24.0');
         }
-        $this->skip('2.24.0', '2.25.1');
+        $this->skip('2.24.0', '2.26.0');
     }
 }

--- a/views/js/test/assets/strategies/test.js
+++ b/views/js/test/assets/strategies/test.js
@@ -2,7 +2,7 @@ define([
     'taoItems/assets/manager',
     'taoItems/assets/strategies'
 ], function(assetManagerFactory, strategies){
-
+    'use strict';
 
     QUnit.module('API');
 
@@ -146,5 +146,50 @@ define([
             var assetManager = assetManagerFactory(strategies.base64);
             assert.equal(assetManager.resolve(data.url), data.resolved, 'The Url is resolved');
         });
+
+
+    QUnit.module('itemCssNoCache strategy');
+
+    QUnit.test('expected strategy format', function(assert){
+
+        QUnit.expect(3);
+
+        assert.ok(typeof strategies.itemCssNoCache === 'object', "The strategy exists");
+        assert.equal(strategies.itemCssNoCache.name, 'itemCssNoCache', "The strategy has the correct name");
+        assert.ok(typeof strategies.itemCssNoCache.handle === 'function', "The strategy has an handler");
+    });
+
+    QUnit.cases([{
+        title    : 'absolute URL',
+        baseUrl  : 'http://tao.localdomain',
+        url      : 'http://tao.localdomain/test/test.css',
+        resolved : '',
+        bust     : false
+    }, {
+        title    : 'relative root URL',
+        baseUrl  : 'http://tao.localdomain/',
+        url      : '/test/test.css',
+        resolved : 'http://tao.localdomain/test/test.css',
+        bust     : true
+    }, {
+        title    : 'relative URL',
+        baseUrl  : 'http://tao.localdomain/',
+        url      : 'test/test.css',
+        resolved : 'http://tao.localdomain/test/test.css',
+        bust     : true
+    }])
+    .test('resolve ', function(data, assert){
+        var assetManager = assetManagerFactory(strategies.itemCssNoCache, {
+            baseUrl : data.baseUrl
+        });
+        var resolved = assetManager.resolve(data.url);
+
+        if(!resolved){
+            assert.ok(data.bust === false, 'No resolution, no buster');
+        } else {
+            assert.equal(resolved.split('?')[0], data.resolved, 'The Url is resolved');
+            assert.equal(/^bust=.*$/.test(resolved.split('?')[1]), data.bust, 'The resolved url has the expected buster');
+        }
+    });
 });
 


### PR DESCRIPTION
Add a new strategy to the asset manager to handle cache busting of item CSS. 