### PR TITLE
Fix/tao 4224 remove tao qti item dependencies

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '4.0.0',
+    'version' => '4.0.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoBackOffice' => '>=0.8',

--- a/models/classes/CategoryService.php
+++ b/models/classes/CategoryService.php
@@ -112,6 +112,7 @@ class CategoryService extends ConfigurableService
     /**
      * Sanitize the name of the category :
      * Remove special chars, replaces spaces by dashes
+     * and the beginning if it's not a letter.
      *
      * @param string $value the input value
      *
@@ -120,7 +121,8 @@ class CategoryService extends ConfigurableService
     public static function sanitizeCategoryName($value)
     {
         $output = preg_replace('/\s+/', '-', trim($value));
-        $output = preg_replace('/[^a-z0-9\-_]/', '',  strtolower($output));
+        $output = preg_replace('/[^a-z0-9\-]/', '',  strtolower($output));
+        $output = preg_replace('/^[0-9\-_]+/', '',  strtolower($output));
         return substr($output, 0, 32);
     }
 

--- a/models/classes/CategoryService.php
+++ b/models/classes/CategoryService.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA
  */
 
 namespace oat\taoItems\model;
@@ -24,7 +24,6 @@ use core_kernel_classes_Class as RdfClass;
 use core_kernel_classes_Property as RdfProperty;
 use core_kernel_classes_Resource as RdfResource;
 use oat\oatbox\service\ConfigurableService;
-use qtism\common\utils\Format;
 use taoItems_models_classes_ItemsService;
 
 /**
@@ -95,17 +94,14 @@ class CategoryService extends ConfigurableService
             $eligibleProperties = $this->getElligibleProperties($class);
             $propertiesValues = $item->getPropertiesValues(array_keys($eligibleProperties));
 
-            foreach ($propertiesValues as $property => $propertyValues) {
+            foreach ($propertiesValues as $propertyValues) {
                 foreach ($propertyValues as $value) {
                     if ($value instanceof RdfResource) {
                         $sanitizedIdentifier = self::sanitizeCategoryName($value->getLabel());
                     } else {
                         $sanitizedIdentifier = self::sanitizeCategoryName((string)$value);
                     }
-
-                    if(Format::isIdentifier($sanitizedIdentifier)){
-                        $categories[] = $sanitizedIdentifier;
-                    }
+                    $categories[] = $sanitizedIdentifier;
                 }
             }
         }

--- a/models/classes/media/LocalItemSource.php
+++ b/models/classes/media/LocalItemSource.php
@@ -24,7 +24,6 @@ use common_exception_Error;
 use oat\oatbox\filesystem\Directory;
 use oat\oatbox\filesystem\File;
 use oat\tao\model\media\MediaManagement;
-use oat\taoQtiItem\model\qti\Item;
 use Psr\Http\Message\StreamInterface;
 use tao_helpers_File;
 use taoItems_models_classes_ItemsService;
@@ -37,9 +36,6 @@ use Slim\Http\Stream;
 class LocalItemSource implements MediaManagement
 {
 
-    /**
-     * @var Item
-     */
     private $item;
     
     private $lang;

--- a/models/classes/pack/ItemPacker.php
+++ b/models/classes/pack/ItemPacker.php
@@ -29,7 +29,7 @@ use oat\oatbox\filesystem\Directory;
  * To allow packing of Item. The goal of the packaging is to represent the data needed
  * to run an item (ie. an ItemPack).
  *
- * @package taoQtiItem
+ * @package taoItems
  */
 abstract class ItemPacker
 {

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -139,6 +139,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.24.0');
         }
 
-        $this->skip('2.24.0', '4.0.0');
+        $this->skip('2.24.0', '4.0.1');
     }
 }

--- a/test/CategoryServiceTest.php
+++ b/test/CategoryServiceTest.php
@@ -50,6 +50,9 @@ class CategoryServiceTest extends TaoPhpUnitTestRunner
     {
         return [
             [" < Hello   My w!%'orld!! ", "hello-my-world"],
+            ["12hello", "hello"],
+            [" hello", "hello"],
+            ["!1h12ello ", "h12ello"],
             ["<span class='hello'>&nbsp;''hello</span> ", "span-classhellonbsphellospan"],
             ["averylongnamethatexceedtheexpectedthritytowcharacters", "averylongnamethatexceedtheexpect"]
         ];


### PR DESCRIPTION
 - I've moved the categories validation to taoQtiTest (in taoItems we don't know the categories will be used in an XML)
 - `LocalItemSource` owns an item, I've removed the phpdoc typing from taoQtiItem (which was incorrect)
 - The preview doesn't fail anymore if a theme wasn't registered.