### PR TITLE
Fix/tao 4317 base64 unicode issue

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,12 +35,12 @@ return array(
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '4.2.0',
+    'version' => '4.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoBackOffice' => '>=0.8',
         'generis' => '>=3.14.0',
-        'tao' => '>=9.0.0'
+        'tao' => '>=10.1.0'
     ),
     'models' => array(
 		'http://www.tao.lu/Ontologies/TAOItem.rdf'

--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return array(
     'requires' => array(
         'taoBackOffice' => '>=0.8',
         'generis' => '>=3.14.0',
-        'tao' => '>=10.1.0'
+        'tao' => '>=10.3.0'
     ),
     'models' => array(
 		'http://www.tao.lu/Ontologies/TAOItem.rdf'

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -139,6 +139,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.24.0');
         }
 
-        $this->skip('2.24.0', '4.2.0');
+        $this->skip('2.24.0', '4.2.1');
     }
 }

--- a/views/js/controller/preview/itemRunner.js
+++ b/views/js/controller/preview/itemRunner.js
@@ -21,6 +21,7 @@ define([
     'module',
     'jquery',
     'lodash',
+    'util/encode',
     'serviceApi/ServiceApi',
     'serviceApi/PseudoStorage',
     'serviceApi/UserInfoService',
@@ -31,6 +32,7 @@ define([
     module,
     $,
     _,
+    encode,
     ServiceApi,
     PseudoStorage,
     UserInfoService,
@@ -103,7 +105,7 @@ define([
 
                         var state;
                         try {
-                            state = JSON.parse(window.atob(conf.state));
+                            state = JSON.parse(encode.decodeBase64(conf.state));
                         } catch(e) {
                             state = null;
                         }

--- a/views/js/controller/preview/itemRunner.js
+++ b/views/js/controller/preview/itemRunner.js
@@ -32,7 +32,7 @@ define([
     module,
     $,
     _,
-    encode,
+    encoder,
     ServiceApi,
     PseudoStorage,
     UserInfoService,
@@ -105,7 +105,7 @@ define([
 
                         var state;
                         try {
-                            state = JSON.parse(encode.decodeBase64(conf.state));
+                            state = JSON.parse(encoder.decodeBase64(conf.state));
                         } catch(e) {
                             state = null;
                         }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TAO-4317

Requires: https://github.com/oat-sa/tao-core/pull/1313

Fix a base64 decoding issue when UTF-8 strings a involved.

The controller encodes the item state using base64 to counter parsing issues. However the unicode string were badly supported.