### PR TITLE
Feature/tao 6458 scorer get qti variables

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,7 +35,7 @@ return array(
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '6.2.0',
+    'version' => '6.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoBackOffice' => '>=3.0.0',

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -102,6 +102,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('6.1.0');
         }
 
-        $this->skip('6.1.0', '6.2.0');
+        $this->skip('6.1.0', '6.3.0');
     }
 }


### PR DESCRIPTION
In the mobile app we use the scoring library to compute the item outcomes. 
By default the outcomes were produced in the PCI format, for example 
```js
{ RESPONSE : {  list : { identifier: ['choice_1', 'choice_2'] } } }
```
But to comply with the Result API we need information like cardinality or baseType, so we expose the state variable with the outcome.
This PR contains ONLY the update in the API (adding the `state` parameter to the callback and give it back to the event)
The file wasn't complying with our ESLint rules, so I did some minor fixes
The API was managing events by itself, so I made it an eventifier too.

To be tested with https://github.com/oat-sa/extension-tao-itemqti/pull/1207