### PR TITLE
TTD-18 missed extending.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -35,11 +35,11 @@ return array(
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '9.2.0',
+    'version' => '10.0.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoBackOffice' => '>=3.0.0',
-        'generis' => '>=8.0.0',
+        'generis' => '>=12.5.0',
         'tao' => '>=38.5.0'
     ),
     'models' => array(

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -116,6 +116,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('9.0.0');
         }
 
-        $this->skip('9.0.0', '9.2.0');
+        $this->skip('9.0.0', '10.0.0');
     }
 }

--- a/test/unit/render/NoneItemReplacementTest.php
+++ b/test/unit/render/NoneItemReplacementTest.php
@@ -19,8 +19,8 @@
  */
 namespace oat\taoItems\test\pack;
 
+use oat\generis\test\TestCase;
 use oat\taoItems\model\render\NoneItemReplacement;
-use PHPUnit\Framework\TestCase;
 
 /**
  * @package taoItems


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
Depends on: https://github.com/oat-sa/generis/pull/678
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.