### PR TITLE
UDI-137: Unicode-aware category sanitization

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.4.1',
+    'version' => '10.4.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/CategoryService.php
+++ b/models/classes/CategoryService.php
@@ -122,7 +122,7 @@ class CategoryService extends ConfigurableService
     public static function sanitizeCategoryName($value)
     {
         $output = preg_replace('/\s+/', '-', trim($value));
-        $output = preg_replace('/[^\p{L}0-9\-]/', '', mb_strtolower($output));
+        $output = preg_replace('/[^\p{L}0-9\-]/u', '', mb_strtolower($output));
         $output = preg_replace('/^[0-9\-_]+/', '', $output);
         return mb_substr($output, 0, 32);
     }

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -118,6 +118,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('9.0.0');
         }
 
-        $this->skip('9.0.0', '10.4.1');
+        $this->skip('9.0.0', '10.4.2');
     }
 }


### PR DESCRIPTION
UDI-137 fix: run unicode-aware `preg_replace()` when removing anything, but characters (including unicode ones), dashes and digits