### PR TITLE
Fix/tca 389/fix s3 latency issue during item import

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.5.1',
+    'version' => '10.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/class.ItemsService.php
+++ b/models/classes/class.ItemsService.php
@@ -311,6 +311,18 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
     }
 
     /**
+     * @param string $itemContentDirectoryName
+     * @param string $actualLang
+     * @return string
+     */
+    public function composeItemDirectoryPath(string $itemContentDirectoryName, string $actualLang): string
+    {
+        $filePath = $itemContentDirectoryName
+            . DIRECTORY_SEPARATOR . 'itemContent' . DIRECTORY_SEPARATOR . $actualLang;
+        return $filePath;
+    }
+
+    /**
      * Woraround for item content
      * (non-PHPdoc)
      * @see tao_models_classes_GenerisService::cloneInstanceProperty()
@@ -565,13 +577,14 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
             throw new common_Exception('Call to ' . __FUNCTION__ . ' for item without model');
         }
 
+        $itemContentDirectoryName = tao_helpers_Uri::getUniqueId($item->getUri());
         // File does not exist, let's create it
         $actualLang = empty($language) ? $this->getSessionLg() : $language;
-        $filePath = tao_helpers_Uri::getUniqueId($item->getUri())
-            . DIRECTORY_SEPARATOR . 'itemContent' . DIRECTORY_SEPARATOR . $actualLang;
+
+        $directoryPath = $this->composeItemDirectoryPath($itemContentDirectoryName, $actualLang);
 
         // Create item directory
-        $itemDirectory = $this->getDefaultItemDirectory()->getDirectory($filePath);
+        $itemDirectory = $this->getDefaultItemDirectory()->getDirectory($directoryPath);
 
         // Set uri file value as serial to item persistence
         $serial = $this->getFileReferenceSerializer()->serialize($itemDirectory);
@@ -622,6 +635,6 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
      */
     protected function getFileReferenceSerializer()
     {
-        return $this->getServiceManager()->get(FileReferenceSerializer::SERVICE_ID);
+        return $this->getServiceLocator()->get(FileReferenceSerializer::SERVICE_ID);
     }
 }

--- a/models/classes/class.ItemsService.php
+++ b/models/classes/class.ItemsService.php
@@ -317,9 +317,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
      */
     public function composeItemDirectoryPath(string $itemContentDirectoryName, string $actualLang): string
     {
-        $filePath = $itemContentDirectoryName
-            . DIRECTORY_SEPARATOR . 'itemContent' . DIRECTORY_SEPARATOR . $actualLang;
-        return $filePath;
+        return  $itemContentDirectoryName . DIRECTORY_SEPARATOR . 'itemContent' . DIRECTORY_SEPARATOR . $actualLang;
     }
 
     /**

--- a/models/classes/media/LocalItemSource.php
+++ b/models/classes/media/LocalItemSource.php
@@ -140,7 +140,7 @@ class LocalItemSource implements MediaManagement
      * Method should be used only after uploading local file, when metadata like file size and mime type
      * of remote uploaded file are not critical. To get more precise info about remote file use getInfoFromFile().
      *
-     * In case of using S3 Flysystem adapter the might be latency and file cannot be accessed right after upload.
+     * In case of using S3 Flysystem adapter there might be latency and file cannot be accessed right after upload.
      *
      * @param File $file
      * @param string $sourceFile

--- a/models/classes/media/LocalItemSource.php
+++ b/models/classes/media/LocalItemSource.php
@@ -137,6 +137,9 @@ class LocalItemSource implements MediaManagement
     }
 
     /**
+     * Method should be used only after uploading local file, when metadata like file size and mime type
+     * of remote uploaded file are not critical. To get more precise info about remote file use getInfoFromFile().
+     *
      * @param File $file
      * @param string $sourceFile
      * @return array

--- a/models/classes/media/LocalItemSource.php
+++ b/models/classes/media/LocalItemSource.php
@@ -29,7 +29,6 @@ use oat\tao\model\media\MediaManagement;
 use Psr\Http\Message\StreamInterface;
 use tao_helpers_File;
 use taoItems_models_classes_ItemsService;
-use Slim\Http\Stream;
 
 /**
  * This media source gives access to files that are part of the item
@@ -137,6 +136,29 @@ class LocalItemSource implements MediaManagement
         return $this->getInfoFromFile($this->getFile($link));
     }
 
+    /**
+     * @param File $file
+     * @param string $sourceFile
+     * @return array
+     * @throws \common_Exception
+     * @throws \tao_models_classes_FileNotFoundException
+     */
+    protected function getInfoFromSource(File $file, string $sourceFile): array
+    {
+        if (file_exists($sourceFile)) {
+            $link = $this->getItemDirectory()->getRelPath($file);
+            return [
+                'name'     => $file->getBasename(),
+                'uri'      => $link,
+                'mime'     => tao_helpers_File::getMimeType($sourceFile),
+                'filePath' => $link,
+                'size'     => filesize($sourceFile),
+            ];
+        } else {
+            return $this->getInfoFromFile($file);
+        }
+    }
+
     protected function getInfoFromFile(File $file)
     {
         $link = $this->getItemDirectory()->getRelPath($file);
@@ -221,7 +243,7 @@ class LocalItemSource implements MediaManagement
             throw new \common_Exception('Unable to write file ("' . $fileName . '")');
         }
 
-        return $this->getInfoFromFile($file);
+        return $this->getInfoFromSource($file, $source);
     }
 
     /**

--- a/models/classes/media/LocalItemSource.php
+++ b/models/classes/media/LocalItemSource.php
@@ -140,6 +140,8 @@ class LocalItemSource implements MediaManagement
      * Method should be used only after uploading local file, when metadata like file size and mime type
      * of remote uploaded file are not critical. To get more precise info about remote file use getInfoFromFile().
      *
+     * In case of using S3 Flysystem adapter the might be latency and file cannot be accessed right after upload.
+     *
      * @param File $file
      * @param string $sourceFile
      * @return array

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -118,6 +118,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('9.0.0');
         }
 
-        $this->skip('9.0.0', '10.5.1');
+        $this->skip('9.0.0', '10.6.0');
     }
 }

--- a/test/unit/models/classes/ItemsServiceTest.php
+++ b/test/unit/models/classes/ItemsServiceTest.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\taoItems\test\unit\models\classes;
+
+use taoItems_models_classes_ItemsService;
+use oat\generis\test\TestCase;
+
+class ItemsServiceTest extends TestCase
+{
+    public function testComposeItemDirectoryPathReturnsStringPath()
+    {
+        $object = new taoItems_models_classes_ItemsService();
+
+        $itemDirectoryName = 'FAKE_DIRECTORY_NAME';
+        $language = 'FAKE_LANGUAGE';
+
+        $result = $object->composeItemDirectoryPath($itemDirectoryName, $language);
+
+        self::assertIsString($result, 'Method must return string directory path.');
+    }
+}
+

--- a/test/unit/models/classes/ItemsServiceTest.php
+++ b/test/unit/models/classes/ItemsServiceTest.php
@@ -17,6 +17,8 @@
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA ;
  */
 
+declare(strict_types=1);
+
 namespace oat\taoItems\test\unit\models\classes;
 
 use taoItems_models_classes_ItemsService;
@@ -26,14 +28,14 @@ class ItemsServiceTest extends TestCase
 {
     public function testComposeItemDirectoryPathReturnsStringPath()
     {
-        $object = new taoItems_models_classes_ItemsService();
+        $itemsService = new taoItems_models_classes_ItemsService();
 
         $itemDirectoryName = 'FAKE_DIRECTORY_NAME';
         $language = 'FAKE_LANGUAGE';
 
-        $result = $object->composeItemDirectoryPath($itemDirectoryName, $language);
+        $path = $itemsService->composeItemDirectoryPath($itemDirectoryName, $language);
 
-        self::assertIsString($result, 'Method must return string directory path.');
+        self::assertIsString($path, 'Method must return string directory path.');
     }
 }
 


### PR DESCRIPTION
JIRA: https://oat-sa.atlassian.net/browse/TCA-389

Problem:
When using S3 flysystem adapter during test import if we call `getSIze()` or `getMimeType()` of just imported file it randomly results in FileNotFound exception (due to latency issue, files appears in S3 after that).

Solution:
After file import use local file source (which was just uploaded to S3) to get file metadata.

How to test: 
- Import QTI item and check that it renders correctly including all required media files.