### PR TITLE
Fix BSA-122: expose only eligible properties as categories

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -21,8 +21,9 @@
  *
  */
 
-use oat\taoItems\scripts\install\RegisterCategoryService;
+use oat\tao\model\user\TaoRoles;
 use oat\taoItems\scripts\install\CreateItemDirectory;
+use oat\taoItems\scripts\install\RegisterCategoryService;
 use oat\taoItems\scripts\install\RegisterNpmPaths;
 
 /*
@@ -30,14 +31,14 @@ use oat\taoItems\scripts\install\RegisterNpmPaths;
  * @license GPLv2  http://www.opensource.org/licenses/gpl-2.0.php
  *
  */
-$extpath = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+$extpath = __DIR__ . DIRECTORY_SEPARATOR;
 
 return [
     'name' => 'taoItems',
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.6.0',
+    'version' => '10.6.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',
@@ -49,10 +50,10 @@ return [
     ],
     'install' => [
         'rdf' => [
-            dirname(__FILE__) . '/models/ontology/taoitem.rdf',
-            dirname(__FILE__) . '/models/ontology/taoItemRunner.rdf',
-            dirname(__FILE__) . '/models/ontology/indexation.rdf',
-            dirname(__FILE__) . '/models/ontology/category.rdf',
+            __DIR__ . '/models/ontology/taoitem.rdf',
+            __DIR__ . '/models/ontology/taoItemRunner.rdf',
+            __DIR__ . '/models/ontology/indexation.rdf',
+            __DIR__ . '/models/ontology/category.rdf',
         ],
         'php'   => [
             CreateItemDirectory::class,
@@ -66,8 +67,8 @@ return [
         ['grant', 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemsManagerRole', ['ext' => 'taoItems']],
         ['grant', 'http://www.tao.lu/Ontologies/TAOItem.rdf#AbstractItemAuthor', 'taoItems_actions_ItemContent'],
         ['grant', 'http://www.tao.lu/Ontologies/TAO.rdf#DeliveryRole', ['ext' => 'taoItems', 'mod' => 'ItemRunner']],
-        ['grant', \oat\tao\model\user\TaoRoles::REST_PUBLISHER, ['ext' => 'taoItems', 'mod' => 'RestItems']],
-        ['grant', \oat\tao\model\user\TaoRoles::REST_PUBLISHER, ['ext' => 'taoItems', 'mod' => 'RestFormItem']],
+        ['grant', TaoRoles::REST_PUBLISHER, ['ext' => 'taoItems', 'mod' => 'RestItems']],
+        ['grant', TaoRoles::REST_PUBLISHER, ['ext' => 'taoItems', 'mod' => 'RestFormItem']],
     ],
     'optimizableClasses' => [
             'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',

--- a/models/classes/CategoryService.php
+++ b/models/classes/CategoryService.php
@@ -92,8 +92,8 @@ class CategoryService extends ConfigurableService
     {
         $categories = [];
         foreach ($item->getTypes() as $class) {
-            $eligibleProperties = $this->getElligibleProperties($class);
-            $propertiesValues = $item->getPropertiesValues(array_keys($eligibleProperties));
+            $eligibleProperties = array_filter($this->getElligibleProperties($class), [$this, 'doesExposeCategory']);
+            $propertiesValues   = $item->getPropertiesValues(array_keys($eligibleProperties));
 
             foreach ($propertiesValues as $propertyValues) {
                 foreach ($propertyValues as $value) {
@@ -140,11 +140,8 @@ class CategoryService extends ConfigurableService
 
         return array_filter(
             $properties,
-            function (RdfProperty $property) {
-                if (
-                    in_array($property->getUri(), self::$excludedPropUris, true)
-                    || !$this->doesExposeCategory($property)
-                ) {
+            static function (RdfProperty $property) {
+                if (in_array($property->getUri(), self::$excludedPropUris, true)) {
                     return false;
                 }
 

--- a/models/classes/CategoryService.php
+++ b/models/classes/CategoryService.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016-2017 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2016-2020 (original work) Open Assessment Technologies SA
  */
 
 namespace oat\taoItems\model;
@@ -23,9 +23,9 @@ namespace oat\taoItems\model;
 use core_kernel_classes_Class as RdfClass;
 use core_kernel_classes_Property as RdfProperty;
 use core_kernel_classes_Resource as RdfResource;
+use oat\generis\model\GenerisRdf;
 use oat\oatbox\service\ConfigurableService;
 use taoItems_models_classes_ItemsService;
-use oat\generis\model\GenerisRdf;
 
 /**
  * Category management service.
@@ -132,19 +132,25 @@ class CategoryService extends ConfigurableService
      *
      * @param RdfClass $class the $class
      *
-     * @return RdfProperties[] the list of eligible properties
+     * @return RdfProperty[] the list of eligible properties
      */
     public function getElligibleProperties(RdfClass $class)
     {
         $properties = $this->getItemService()->getClazzProperties($class, new RdfClass(self::ITEM_CLASS_URI));
+
         return array_filter(
             $properties,
-            function ($property) {
-                if (in_array($property->getUri(), self::$excludedPropUris)) {
+            function (RdfProperty $property) {
+                if (
+                    in_array($property->getUri(), self::$excludedPropUris, true)
+                    || !$this->doesExposeCategory($property)
+                ) {
                     return false;
                 }
+
                 $widget = $property->getWidget();
-                return !is_null($widget) && in_array($widget->getUri(), self::$supportedWidgetUris);
+
+                return null !== $widget && in_array($widget->getUri(), self::$supportedWidgetUris, true);
             }
         );
     }
@@ -152,7 +158,7 @@ class CategoryService extends ConfigurableService
     /**
      * Check if a property is exposed
      *
-     * @param RdfPropery $property the property to check
+     * @param RdfProperty $property the property to check
      *
      * @return bool true if exposed
      */

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -20,21 +20,22 @@
  *
  */
 
-use oat\tao\scripts\update\OntologyUpdater;
-use oat\tao\model\accessControl\func\AclProxy;
 use oat\tao\model\accessControl\func\AccessRule;
-use oat\taoItems\model\CategoryService;
-use oat\taoItems\model\render\NoneItemReplacement;
-use oat\taoItems\model\render\ItemAssetsReplacement;
-use oat\taoItems\model\preview\ItemPreviewerService;
+use oat\tao\model\accessControl\func\AclProxy;
 use oat\tao\model\asset\AssetService;
 use oat\tao\model\ClientLibRegistry;
+use oat\tao\model\user\TaoRoles;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\taoItems\model\CategoryService;
+use oat\taoItems\model\preview\ItemPreviewerService;
+use oat\taoItems\model\render\ItemAssetsReplacement;
+use oat\taoItems\model\render\NoneItemReplacement;
 
 /**
  *
  * @author Joel Bout <joel@taotesting.com>
  */
-class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater
+class taoItems_scripts_update_Updater extends common_ext_ExtensionUpdater
 {
 
     /**
@@ -47,7 +48,7 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater
 
 
         if ($this->isBetween('0.0.0', '2.8.0')) {
-            throw new \common_exception_NotImplemented('Updates from versions prior to Tao 3.1 are not longer supported, please update to Tao 3.1 first');
+            throw new common_exception_NotImplemented('Updates from versions prior to Tao 3.1 are not longer supported, please update to Tao 3.1 first');
         }
 
         $this->skip('2.8.1', '2.22.3');
@@ -78,8 +79,8 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater
         $this->skip('5.6.0', '5.9.0');
 
         if ($this->isVersion('5.9.0')) {
-            AclProxy::applyRule(new AccessRule('grant', \oat\tao\model\user\TaoRoles::REST_PUBLISHER, ['ext' => 'taoItems', 'mod' => 'RestItems']));
-            AclProxy::applyRule(new AccessRule('grant', \oat\tao\model\user\TaoRoles::REST_PUBLISHER, ['ext' => 'taoItems', 'mod' => 'RestFormItem']));
+            AclProxy::applyRule(new AccessRule('grant', TaoRoles::REST_PUBLISHER, ['ext' => 'taoItems', 'mod' => 'RestItems']));
+            AclProxy::applyRule(new AccessRule('grant', TaoRoles::REST_PUBLISHER, ['ext' => 'taoItems', 'mod' => 'RestFormItem']));
             $this->setVersion('5.10.0');
         }
 
@@ -118,6 +119,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('9.0.0');
         }
 
-        $this->skip('9.0.0', '10.6.0');
+        $this->skip('9.0.0', '10.6.1');
     }
 }

--- a/test/unit/models/classes/CategoryServiceTest.php
+++ b/test/unit/models/classes/CategoryServiceTest.php
@@ -15,38 +15,26 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA
+ * Copyright (c) 2016-2020 (original work) Open Assessment Technologies SA
  */
 
-namespace oat\taoItems\test\integration;
+namespace oat\taoItems\test\unit\models\classes;
 
-use oat\generis\model\GenerisRdf;
-use Prophecy\Argument;
-use Prophecy\Prophet;
-use core_kernel_classes_Class    as RdfClass;
+use core_kernel_classes_Class as RdfClass;
 use core_kernel_classes_Property as RdfProperty;
 use core_kernel_classes_Resource as RdfResource;
+use oat\generis\model\GenerisRdf;
+use oat\generis\test\TestCase;
 use oat\taoItems\model\CategoryService;
-use oat\tao\test\TaoPhpUnitTestRunner;
-use taoItems_models_classes_ItemsService;
-
-include_once dirname(__FILE__) . '/../../includes/raw_start.php';
+use Prophecy\Argument;
 
 /**
  * CategoryService test
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-class CategoryServiceTest extends TaoPhpUnitTestRunner
+class CategoryServiceTest extends TestCase
 {
-    /**
-     * Tests initialization
-     */
-    public function setUp(): void
-    {
-        TaoPhpUnitTestRunner::initTest();
-    }
-
     /**
      * testSanitize data provider
      */
@@ -105,26 +93,36 @@ class CategoryServiceTest extends TaoPhpUnitTestRunner
      */
     public function testGetElligibleProperties()
     {
-        $fooClass = new RdfClass('foo');
+        $fooClass       = new RdfClass('foo');
+        $exposeProperty = new RdfProperty(CategoryService::EXPOSE_PROP_URI);
+        $trueResource   = new RdfResource(GenerisRdf::GENERIS_TRUE);
+        $falseResource  = new RdfResource(GenerisRdf::GENERIS_FALSE);
 
         $eligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
         $eligibleProp1->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[0]));
+        $eligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $eligibleProp1->getUri()->willReturn('p1');
 
         $eligibleProp2 = $this->prophesize('\core_kernel_classes_Property');
         $eligibleProp2->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[2]));
+        $eligibleProp2->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $eligibleProp2->getUri()->willReturn('p2');
 
         $notEligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
+        $notEligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $notEligibleProp1->getWidget()->willReturn(null);
         $notEligibleProp1->getUri()->willReturn('np1');
 
         $notEligibleProp2 = $this->prophesize('\core_kernel_classes_Property');
+        $notEligibleProp2->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $notEligibleProp2->getWidget()->willReturn(new RdfResource('http://www.tao.lu/datatypes/WidgetDefinitions.rdf#HtmlBox'));
         $notEligibleProp2->getUri()->willReturn('np2');
 
+        $notEligibleProp3 = $this->prophesize('\core_kernel_classes_Property');
+        $notEligibleProp3->getOnePropertyValue($exposeProperty)->willReturn($falseResource);
+        $notEligibleProp3->getUri()->willReturn('np3');
+
         $excludedProp1 = $this->prophesize('\core_kernel_classes_Property');
-        $excludedProp1->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[0]));
         $excludedProp1->getUri()->willReturn(CategoryService::$excludedPropUris[0]);
 
         $itemService = $this->prophesize('\taoItems_models_classes_ItemsService');
@@ -133,6 +131,7 @@ class CategoryServiceTest extends TaoPhpUnitTestRunner
             $eligibleProp2->reveal(),
             $notEligibleProp1->reveal(),
             $notEligibleProp2->reveal(),
+            $notEligibleProp3->reveal(),
             $excludedProp1->reveal()
         ]);
 
@@ -141,7 +140,7 @@ class CategoryServiceTest extends TaoPhpUnitTestRunner
 
         $result = $categoryService->getElligibleProperties($fooClass);
 
-        $this->assertEquals(2, count($result), "We have 2 eligible properties");
+        $this->assertCount(2, $result, "We have 2 eligible properties");
         $this->assertEquals('p1', $result[0]->getUri(), "We have an eligible properties");
         $this->assertEquals('p2', $result[1]->getUri(), "We have an eligible properties");
     }
@@ -151,13 +150,17 @@ class CategoryServiceTest extends TaoPhpUnitTestRunner
      */
     public function testGetItemCategories()
     {
-        $fooClass = new RdfClass('foo');
+        $fooClass       = new RdfClass('foo');
+        $exposeProperty = new RdfProperty(CategoryService::EXPOSE_PROP_URI);
+        $trueResource   = new RdfResource(GenerisRdf::GENERIS_TRUE);
 
         $eligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
+        $eligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $eligibleProp1->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[0]));
         $eligibleProp1->getUri()->willReturn('p1');
 
         $eligibleProp2 = $this->prophesize('\core_kernel_classes_Property');
+        $eligibleProp2->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $eligibleProp2->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[2]));
         $eligibleProp2->getUri()->willReturn('p2');
 
@@ -182,7 +185,7 @@ class CategoryServiceTest extends TaoPhpUnitTestRunner
 
         $categories = $categoryService->getItemCategories($item->reveal());
 
-        $this->assertEquals(3, count($categories), "We have 3 categories");
+        $this->assertCount(3, $categories, "We have 3 categories");
         $this->assertEquals('foo', $categories[0], "The category matches");
         $this->assertEquals('yo-bar', $categories[1], "The category matches");
         $this->assertEquals('yeah-moo', $categories[2], "The category matches");

--- a/test/unit/models/classes/CategoryServiceTest.php
+++ b/test/unit/models/classes/CategoryServiceTest.php
@@ -141,7 +141,7 @@ class CategoryServiceTest extends TestCase
         $fooClass       = new RdfClass('foo');
         $exposeProperty = new RdfProperty(CategoryService::EXPOSE_PROP_URI);
         $trueResource   = new RdfResource(GenerisRdf::GENERIS_TRUE);
-        $falseResource  = new RdfResource(GenerisRdf::GENERIS_TRUE);
+        $falseResource  = new RdfResource(GenerisRdf::GENERIS_FALSE);
 
         $eligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
         $eligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
@@ -162,10 +162,14 @@ class CategoryServiceTest extends TestCase
         $p2Value->getLabel()->willReturn('Yeah Moo');
 
         $item = $this->prophesize('\core_kernel_classes_Resource');
-        $item->getPropertiesValues(Argument::any())->willReturn([
-            'p1' => ['Foo', 'Yo _Bar '],
-            'p2' => [$p2Value->reveal()]
-        ]);
+        $item
+            ->getPropertiesValues(['p1', 'p2'])
+            ->willReturn(
+                [
+                    'p1' => ['Foo', 'Yo _Bar '],
+                    'p2' => [$p2Value->reveal()],
+                ]
+            );
         $item->getTypes()->willReturn([$fooClass]);
 
         $itemService = $this->prophesize('\taoItems_models_classes_ItemsService');

--- a/test/unit/models/classes/CategoryServiceTest.php
+++ b/test/unit/models/classes/CategoryServiceTest.php
@@ -93,34 +93,23 @@ class CategoryServiceTest extends TestCase
      */
     public function testGetElligibleProperties()
     {
-        $fooClass       = new RdfClass('foo');
-        $exposeProperty = new RdfProperty(CategoryService::EXPOSE_PROP_URI);
-        $trueResource   = new RdfResource(GenerisRdf::GENERIS_TRUE);
-        $falseResource  = new RdfResource(GenerisRdf::GENERIS_FALSE);
+        $fooClass = new RdfClass('foo');
 
         $eligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
         $eligibleProp1->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[0]));
-        $eligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $eligibleProp1->getUri()->willReturn('p1');
 
         $eligibleProp2 = $this->prophesize('\core_kernel_classes_Property');
         $eligibleProp2->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[2]));
-        $eligibleProp2->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $eligibleProp2->getUri()->willReturn('p2');
 
         $notEligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
-        $notEligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $notEligibleProp1->getWidget()->willReturn(null);
         $notEligibleProp1->getUri()->willReturn('np1');
 
         $notEligibleProp2 = $this->prophesize('\core_kernel_classes_Property');
-        $notEligibleProp2->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $notEligibleProp2->getWidget()->willReturn(new RdfResource('http://www.tao.lu/datatypes/WidgetDefinitions.rdf#HtmlBox'));
         $notEligibleProp2->getUri()->willReturn('np2');
-
-        $notEligibleProp3 = $this->prophesize('\core_kernel_classes_Property');
-        $notEligibleProp3->getOnePropertyValue($exposeProperty)->willReturn($falseResource);
-        $notEligibleProp3->getUri()->willReturn('np3');
 
         $excludedProp1 = $this->prophesize('\core_kernel_classes_Property');
         $excludedProp1->getUri()->willReturn(CategoryService::$excludedPropUris[0]);
@@ -131,7 +120,6 @@ class CategoryServiceTest extends TestCase
             $eligibleProp2->reveal(),
             $notEligibleProp1->reveal(),
             $notEligibleProp2->reveal(),
-            $notEligibleProp3->reveal(),
             $excludedProp1->reveal()
         ]);
 
@@ -153,6 +141,7 @@ class CategoryServiceTest extends TestCase
         $fooClass       = new RdfClass('foo');
         $exposeProperty = new RdfProperty(CategoryService::EXPOSE_PROP_URI);
         $trueResource   = new RdfResource(GenerisRdf::GENERIS_TRUE);
+        $falseResource  = new RdfResource(GenerisRdf::GENERIS_TRUE);
 
         $eligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
         $eligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
@@ -163,6 +152,11 @@ class CategoryServiceTest extends TestCase
         $eligibleProp2->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
         $eligibleProp2->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[2]));
         $eligibleProp2->getUri()->willReturn('p2');
+
+        $notEligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
+        $notEligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($falseResource);
+        $notEligibleProp1->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[2]));
+        $notEligibleProp1->getUri()->willReturn('np1');
 
         $p2Value = $this->prophesize('\core_kernel_classes_Resource');
         $p2Value->getLabel()->willReturn('Yeah Moo');
@@ -175,10 +169,15 @@ class CategoryServiceTest extends TestCase
         $item->getTypes()->willReturn([$fooClass]);
 
         $itemService = $this->prophesize('\taoItems_models_classes_ItemsService');
-        $itemService->getClazzProperties($fooClass, Argument::any())->willReturn([
-            'p1' => $eligibleProp1->reveal(),
-            'p2' => $eligibleProp2->reveal()
-        ]);
+        $itemService
+            ->getClazzProperties($fooClass, Argument::any())
+            ->willReturn(
+                [
+                    'p1'  => $eligibleProp1->reveal(),
+                    'p2'  => $eligibleProp2->reveal(),
+                    'np1' => $notEligibleProp1->reveal(),
+                ]
+            );
 
         $categoryService = new CategoryService();
         $categoryService->setItemService($itemService->reveal());


### PR DESCRIPTION
- [BSA-122](https://oat-sa.atlassian.net/browse/BSA-122) fix: expose only eligible item properties as test-item categories