### PR TITLE
BSA-126 fix: do not expose empty values as test-item categories

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.6.1',
+    'version' => '10.6.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/CategoryService.php
+++ b/models/classes/CategoryService.php
@@ -91,6 +91,7 @@ class CategoryService extends ConfigurableService
     public function getItemCategories(RdfResource $item)
     {
         $categories = [];
+
         foreach ($item->getTypes() as $class) {
             $eligibleProperties = array_filter($this->getElligibleProperties($class), [$this, 'doesExposeCategory']);
             $propertiesValues   = $item->getPropertiesValues(array_keys($eligibleProperties));
@@ -102,7 +103,10 @@ class CategoryService extends ConfigurableService
                     } else {
                         $sanitizedIdentifier = self::sanitizeCategoryName((string)$value);
                     }
-                    $categories[] = $sanitizedIdentifier;
+
+                    if ($sanitizedIdentifier) {
+                        $categories[] = $sanitizedIdentifier;
+                    }
                 }
             }
         }

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -119,6 +119,6 @@ class taoItems_scripts_update_Updater extends common_ext_ExtensionUpdater
             $this->setVersion('9.0.0');
         }
 
-        $this->skip('9.0.0', '10.6.1');
+        $this->skip('9.0.0', '10.6.2');
     }
 }

--- a/test/unit/models/classes/CategoryServiceTest.php
+++ b/test/unit/models/classes/CategoryServiceTest.php
@@ -153,6 +153,11 @@ class CategoryServiceTest extends TestCase
         $eligibleProp2->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[2]));
         $eligibleProp2->getUri()->willReturn('p2');
 
+        $eligibleProp3 = $this->prophesize('\core_kernel_classes_Property');
+        $eligibleProp3->getOnePropertyValue($exposeProperty)->willReturn($trueResource);
+        $eligibleProp3->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[3]));
+        $eligibleProp3->getUri()->willReturn('p3');
+
         $notEligibleProp1 = $this->prophesize('\core_kernel_classes_Property');
         $notEligibleProp1->getOnePropertyValue($exposeProperty)->willReturn($falseResource);
         $notEligibleProp1->getWidget()->willReturn(new RdfResource(CategoryService::$supportedWidgetUris[2]));
@@ -163,11 +168,12 @@ class CategoryServiceTest extends TestCase
 
         $item = $this->prophesize('\core_kernel_classes_Resource');
         $item
-            ->getPropertiesValues(['p1', 'p2'])
+            ->getPropertiesValues(['p1', 'p2', 'p3'])
             ->willReturn(
                 [
                     'p1' => ['Foo', 'Yo _Bar '],
                     'p2' => [$p2Value->reveal()],
+                    'p3' => [''],
                 ]
             );
         $item->getTypes()->willReturn([$fooClass]);
@@ -179,6 +185,7 @@ class CategoryServiceTest extends TestCase
                 [
                     'p1'  => $eligibleProp1->reveal(),
                     'p2'  => $eligibleProp2->reveal(),
+                    'p3'  => $eligibleProp3->reveal(),
                     'np1' => $notEligibleProp1->reveal(),
                 ]
             );


### PR DESCRIPTION
[BSA-126](https://oat-sa.atlassian.net/browse/BSA-126) fix: do not expose empty values as test-item categories

Couldn't really reproduce it, as it seems the fix was applied on the front-end side at some point as well, but now the response to `getItems` request during authoring doesn't contain any empty `categories` values.
One way to check is to create an exposed item property and set its value to a digit or a set of digits without any letters.

Related to [`taoQtiTest #1800`](https://github.com/oat-sa/extension-tao-testqti/pull/1800).