### PR TITLE
Fix/BSA-202/Trouble with booklet generaion

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.8.3',
+    'version' => '10.8.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/pack/ItemPack.php
+++ b/models/classes/pack/ItemPack.php
@@ -240,8 +240,8 @@ class ItemPack implements JsonSerializable
      * @param string|MediaAsset $asset
      *
      * @throws FileNotFoundException
-     * @throws LogicException
-     *@return string
+     *
+     * @return string
      */
     private function getAssetKey($asset): string
     {

--- a/test/unit/pack/encoder/Base64fileEncoderTest.php
+++ b/test/unit/pack/encoder/Base64fileEncoderTest.php
@@ -34,10 +34,6 @@ use Psr\Http\Message\StreamInterface;
  */
 class Base64fileEncoderTest extends TestCase
 {
-
-    protected $directoryStorage;
-
-
     public function resourceProvider()
     {
         $stream = $this->getMockBuilder(StreamInterface::class)
@@ -97,7 +93,7 @@ class Base64fileEncoderTest extends TestCase
 
         $directoryStorage->method('getFile')->with('exist.css')->willReturn($file);
 
-        $encoder = new Base64fileEncoder($directoryStorage, 'en_US');
+        $encoder = new Base64fileEncoder($directoryStorage);
         $this->assertEquals($expected, $encoder->encode($data));
     }
 
@@ -116,7 +112,7 @@ class Base64fileEncoderTest extends TestCase
 
         $directoryStorage->method('getFile')->with('notExist.css')->willReturn($file);
 
-        $encoder = new Base64fileEncoder($directoryStorage, 'en_US');
+        $encoder = new Base64fileEncoder($directoryStorage);
         $this->assertEquals('doesn\'t mater', $encoder->encode('notExist.css'));
     }
 }


### PR DESCRIPTION
Related to: [BSA-202](https://oat-sa.atlassian.net/browse/BSA-202)

**Changes:**
* Added `publicDirectory` argument when setting assets;
* Removed unnecessary argument which was used for `Base64fileEncoder` creation (tests).

**How to test:**
1. Create an item with an image;
2. Create a test and add this item to it;
3. Generate booklet for this test;
4. Go to the Booklets page and select the necessary booklet;
5. Click `Preview`;

_Previous: error._
_Now: the created booklet can be previewed._