### PR TITLE
[TAO-10170] Fix: Do not allow to preview empty items

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.8.3',
+    'version' => '10.8.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.8.1',
+    'version' => '10.8.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/class.ItemsService.php
+++ b/models/classes/class.ItemsService.php
@@ -200,7 +200,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
      */
     public function hasItemModel(core_kernel_classes_Resource $item, $models)
     {
-        $returnValue = (bool)false;
+        $returnValue = false;
 
         $itemModel = $item->getOnePropertyValue($this->getItemModelProperty());
         if ($itemModel instanceof core_kernel_classes_Resource) {
@@ -209,7 +209,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
             }
         }
 
-        return (bool)$returnValue;
+        return $returnValue;
     }
 
     /**
@@ -222,7 +222,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
      */
     public function isItemModelDefined(core_kernel_classes_Resource $item)
     {
-        $returnValue = (bool)false;
+        $returnValue = false;
 
         if (!is_null($item)) {
             $model = $item->getOnePropertyValue($this->getItemModelProperty());
@@ -235,7 +235,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
             }
         }
 
-        return (bool)$returnValue;
+        return $returnValue;
     }
 
     /**
@@ -271,7 +271,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
      */
     public function hasModelStatus(core_kernel_classes_Resource $item, $status)
     {
-        $returnValue = (bool)false;
+        $returnValue = false;
 
         if (!is_null($item)) {
             if (!is_array($status) && is_string($status)) {
@@ -290,7 +290,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
             }
         }
 
-        return (bool)$returnValue;
+        return $returnValue;
     }
 
     /**
@@ -304,7 +304,6 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
      */
     public function render(core_kernel_classes_Resource $item, $language)
     {
-
         $itemModel = $this->getItemModel($item);
         if (is_null($itemModel)) {
             throw new common_exception_NoImplementation('No item model for item ' . $item->getUri());
@@ -435,7 +434,6 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
         return $item->editPropertyValues($this->getProperty(self::PROPERTY_ITEM_MODEL), $model);
     }
 
-
     /**
      * Rertrieve current user's language from the session object to know where
      * item content should be located
@@ -446,7 +444,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
      */
     public function getSessionLg()
     {
-        $sessionLang = common_session_SessionManager::getSession()->getDataLanguage();
+        $sessionLang = \common_session_SessionManager::getSession()->getDataLanguage();
         if (empty($sessionLang)) {
             throw new Exception('the data language of the user cannot be found in session');
         }
@@ -489,7 +487,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
 
     /**
      * Get the correct implementation for a specific item model
-     *
+     * @author Joel Bout, <joel@taotesting.com>
      * @access public
      *
      * @param  core_kernel_classes_Resource $itemModel
@@ -497,11 +495,9 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
      * @return taoItems_models_classes_itemModel
      * @throws common_exception_NoImplementation
      * @throws common_exception_Error
-     *@author Joel Bout, <joel@taotesting.com>
      */
     public function getItemModelImplementation(core_kernel_classes_Resource $itemModel)
     {
-
         $serviceId = (string)$itemModel->getOnePropertyValue($this->getProperty(self::PROPERTY_ITEM_MODEL_SERVICE));
         if (empty($serviceId)) {
             throw new common_exception_NoImplementation('No implementation found for item model ' . $itemModel->getUri());
@@ -519,6 +515,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
         if (!$itemModelService instanceof taoItems_models_classes_itemModel) {
             throw new common_exception_Error('Item model service ' . get_class($itemModelService) . ' not compatible for item model ' . $serviceId);
         }
+
         return $itemModelService;
     }
 


### PR DESCRIPTION
Ticket: [TAO-10170](https://oat-sa.atlassian.net/browse/TAO-10170)

Fixed \taoItems_models_classes_ItemsService::hasItemContent

Now it checks if `qti.xml` of an item really exists. not only item properties. It allows disabling `Preview` button if there is nothing to preview

the other part  of the fix is here oat-sa/extension-tao-testqti-previewer#79