### PR TITLE
Fix/BSA-202/Fix booklet generation and preview for the imported items with the shared stimulus images

### DIFF
--- a/actions/class.ItemPreview.php
+++ b/actions/class.ItemPreview.php
@@ -21,6 +21,7 @@
  *               2013-2018(update and modification) Open Assessment Technologies SA;
  */
 
+use oat\tao\helpers\Base64;
 use oat\generis\model\OntologyAwareTrait;
 use oat\taoItems\model\media\ItemMediaResolver;
 use oat\tao\model\media\sourceStrategy\HttpSource;
@@ -84,7 +85,7 @@ class taoItems_actions_ItemPreview extends tao_actions_CommonModule
     public function render()
     {
         $relPath = tao_helpers_Request::getRelativeUrl();
-        list($extension, $module, $action, $codedUri, $path) = explode('/', $relPath, 5);
+        [$extension, $module, $action, $codedUri, $path] = explode('/', $relPath, 5);
 
         $path = rawurldecode($path);
         $uri = base64_decode($codedUri);
@@ -120,16 +121,27 @@ class taoItems_actions_ItemPreview extends tao_actions_CommonModule
         $this->response = $this->response->withBody(stream_for($this->getRenderedItem($item)));
     }
 
+    /**
+     * @param $item
+     * @param $path
+     *
+     * @throws common_Exception
+     * @throws common_exception_Error
+     * @throws tao_models_classes_FileNotFoundException
+     */
     private function renderResource($item, $path)
     {
         $lang = $this->getSession()->getDataLanguage();
         $resolver = new ItemMediaResolver($item, $lang);
         $asset = $resolver->resolve($path);
-        if ($asset->getMediaSource() instanceof HttpSource) {
+        $mediaSource = $asset->getMediaSource();
+
+        if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($mediaSource)) {
             throw new common_Exception('Only tao files available for rendering through item preview');
         }
-        $info = $asset->getMediaSource()->getFileInfo($asset->getMediaIdentifier());
-        $stream = $asset->getMediaSource()->getFileStream($asset->getMediaIdentifier());
+
+        $info = $mediaSource->getFileInfo($asset->getMediaIdentifier());
+        $stream = $mediaSource->getFileStream($asset->getMediaIdentifier());
         \tao_helpers_Http::returnStream($stream, $info['mime']);
     }
 

--- a/actions/class.ItemPreview.php
+++ b/actions/class.ItemPreview.php
@@ -135,13 +135,14 @@ class taoItems_actions_ItemPreview extends tao_actions_CommonModule
         $resolver = new ItemMediaResolver($item, $lang);
         $asset = $resolver->resolve($path);
         $mediaSource = $asset->getMediaSource();
+        $mediaIdentifier = $asset->getMediaIdentifier();
 
-        if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($mediaSource)) {
+        if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($mediaIdentifier)) {
             throw new common_Exception('Only tao files available for rendering through item preview');
         }
 
-        $info = $mediaSource->getFileInfo($asset->getMediaIdentifier());
-        $stream = $mediaSource->getFileStream($asset->getMediaIdentifier());
+        $info = $mediaSource->getFileInfo($mediaIdentifier);
+        $stream = $mediaSource->getFileStream($mediaIdentifier);
         \tao_helpers_Http::returnStream($stream, $info['mime']);
     }
 

--- a/manifest.php
+++ b/manifest.php
@@ -38,12 +38,12 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.8.5',
+    'version' => '10.9.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',
         'generis' => '>=12.5.0',
-        'tao' => '>=45.1.3'
+        'tao' => '>=45.2.0'
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAOItem.rdf'

--- a/manifest.php
+++ b/manifest.php
@@ -38,12 +38,12 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.8.4',
+    'version' => '10.8.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',
         'generis' => '>=12.5.0',
-        'tao' => '>=38.5.0'
+        'tao' => '>=45.1.3'
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAOItem.rdf'

--- a/models/classes/pack/ItemPack.php
+++ b/models/classes/pack/ItemPack.php
@@ -254,15 +254,16 @@ class ItemPack implements JsonSerializable
         }
 
         $mediaSource = $asset->getMediaSource();
+        $mediaIdentifier = $asset->getMediaIdentifier();
 
         if (
             $mediaSource instanceof MediaSource
             || $mediaSource instanceof HttpSource
-            || Base64::isEncodedImage($mediaSource)
+            || Base64::isEncodedImage($mediaIdentifier)
         ) {
-            return $asset->getMediaIdentifier();
+            return $mediaIdentifier;
         }
 
-        return $mediaSource->getBaseName($asset->getMediaIdentifier());
+        return $mediaSource->getBaseName($mediaIdentifier);
     }
 }

--- a/models/classes/pack/ItemPack.php
+++ b/models/classes/pack/ItemPack.php
@@ -25,6 +25,7 @@ namespace oat\taoItems\model\pack;
 
 use LogicException;
 use \JsonSerializable;
+use oat\tao\helpers\Base64;
 use \InvalidArgumentException;
 use oat\tao\model\media\MediaAsset;
 use oat\taoMediaManager\model\MediaSource;
@@ -254,7 +255,11 @@ class ItemPack implements JsonSerializable
 
         $mediaSource = $asset->getMediaSource();
 
-        if ($mediaSource instanceof MediaSource || $mediaSource instanceof HttpSource) {
+        if (
+            $mediaSource instanceof MediaSource
+            || $mediaSource instanceof HttpSource
+            || Base64::isEncodedImage($mediaSource)
+        ) {
             return $asset->getMediaIdentifier();
         }
 

--- a/models/classes/pack/encoders/Base64fileEncoder.php
+++ b/models/classes/pack/encoders/Base64fileEncoder.php
@@ -75,7 +75,7 @@ class Base64fileEncoder implements Encoding
             $mediaSource = $data->getMediaSource();
             $data = $data->getMediaIdentifier();
 
-            if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($mediaSource)) {
+            if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($data)) {
                 return $data;
             }
 

--- a/models/classes/pack/encoders/Base64fileEncoder.php
+++ b/models/classes/pack/encoders/Base64fileEncoder.php
@@ -71,7 +71,7 @@ class Base64fileEncoder implements Encoding
             $mediaSource = $data->getMediaSource();
             $data = $data->getMediaIdentifier();
 
-            if ($mediaSource instanceof HttpSource) {
+            if ($mediaSource instanceof HttpSource || preg_match('/^(data:.*;base64)/', $data)) {
                 return $data;
             }
 

--- a/models/classes/pack/encoders/NoneEncoder.php
+++ b/models/classes/pack/encoders/NoneEncoder.php
@@ -53,12 +53,13 @@ class NoneEncoder implements Encoding
     {
         if ($data instanceof MediaAsset) {
             $mediaSource = $data->getMediaSource();
+            $mediaIdentifier = $data->getMediaIdentifier();
 
-            if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($mediaSource)) {
-                return $data->getMediaIdentifier();
+            if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($mediaIdentifier)) {
+                return $mediaIdentifier;
             }
 
-            return $mediaSource->getBaseName($data->getMediaIdentifier());
+            return $mediaSource->getBaseName($mediaIdentifier);
         }
 
         return $data;

--- a/models/classes/pack/encoders/NoneEncoder.php
+++ b/models/classes/pack/encoders/NoneEncoder.php
@@ -15,15 +15,23 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2015-2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
  * @author Mikhail Kamarouski, <kamarouski@1pt.com>
  */
 
 namespace oat\taoItems\model\pack\encoders;
 
+use oat\tao\helpers\Base64;
 use oat\tao\model\media\MediaAsset;
+use tao_models_classes_FileNotFoundException;
 use oat\tao\model\media\sourceStrategy\HttpSource;
 
+/**
+ * Class NoneEncoder
+ *
+ * @package oat\taoItems\model\pack\encoders
+ */
 class NoneEncoder implements Encoding
 {
     /**
@@ -37,17 +45,22 @@ class NoneEncoder implements Encoding
     /**
      * @param mixed $data
      *
-     * @return string
+     * @throws tao_models_classes_FileNotFoundException
+     *
+     * @return mixed|string
      */
     public function encode($data)
     {
         if ($data instanceof MediaAsset) {
             $mediaSource = $data->getMediaSource();
-            if ($mediaSource instanceof HttpSource) {
+
+            if ($mediaSource instanceof HttpSource || Base64::isEncodedImage($mediaSource)) {
                 return $data->getMediaIdentifier();
             }
+
             return $mediaSource->getBaseName($data->getMediaIdentifier());
         }
+
         return $data;
     }
 }


### PR DESCRIPTION
Relates to: [BSA-202](https://oat-sa.atlassian.net/browse/BSA-202)

**Changes:**
* Added pattern to check if media data is a base64 image.

**How to test:**
1. Create a new Asset with an image;
2. Create a new item and add the shared stimulus element, which was created in step 1;
3. Create a new test and add this item;
4. Generate the booklet and check it (preview) - everything will be OK;
5. Export and import this test;
6. Generate the booklet for the imported test and check it (preview) .

_**Previous behaviour:** error. Item cannot be packed._
_**Current behaviour:** no error, preview works as expected._

**Require:**
* [#2621](https://github.com/oat-sa/tao-core/pull/2621)