### PR TITLE
Feature/CGA-97/Allow registering item previewer plugins (Sprint 127)

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -37,7 +37,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.5.0',
+    'version' => '10.5.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/scripts/update/class.Updater.php
+++ b/scripts/update/class.Updater.php
@@ -118,6 +118,6 @@ class taoItems_scripts_update_Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('9.0.0');
         }
 
-        $this->skip('9.0.0', '10.5.0');
+        $this->skip('9.0.0', '10.5.1');
     }
 }

--- a/test/unit/preview/ItemPreviewerServiceTest.php
+++ b/test/unit/preview/ItemPreviewerServiceTest.php
@@ -72,6 +72,38 @@ class ItemPreviewerServiceTest extends TestCase
                         'previewer'
                     ]
                 ]
+            ],
+            'plugins' => [
+                [
+                    'id' => 'plugin1',
+                    'module' => 'taoQtiTest/previewer/plugins/plugin1',
+                    'bundle' => 'taoQtiTest/loader/qtiPlugins.min',
+                    'position' => null,
+                    'name' => 'Plugin 1',
+                    'description' => 'Sample plugin 1',
+                    'category' => 'previewer',
+                    'active' => true,
+                    'tags' => [
+                        'core',
+                        'qti',
+                        'previewer'
+                    ]
+                ],
+                [
+                    'id' => 'plugin2',
+                    'module' => 'taoQtiTest/previewer/plugins/plugin2',
+                    'bundle' => 'taoQtiTest/loader/qtiPlugins.min',
+                    'position' => null,
+                    'name' => 'Plugin 2',
+                    'description' => 'Sample plugin 2',
+                    'category' => 'previewer',
+                    'active' => false,
+                    'tags' => [
+                        'core',
+                        'qti',
+                        'previewer'
+                    ]
+                ]
             ]
         ]
     ];
@@ -153,6 +185,46 @@ class ItemPreviewerServiceTest extends TestCase
     }
 
     /**
+     * Test the method ItemPreviewerService::getPlugins
+     */
+    public function testGetPlugins()
+    {
+        $itemPreviewerService = $this->getItemPreviewerService();
+
+        $plugins = $itemPreviewerService->getPlugins();
+
+        $this->assertEquals(2, count($plugins));
+
+        $this->assertArrayHasKey('0', $plugins);
+        $plugin0 = $plugins[0];
+        $this->assertArrayHasKey('id', $plugin0);
+        $this->assertArrayHasKey('module', $plugin0);
+        $this->assertArrayHasKey('bundle', $plugin0);
+        $this->assertArrayHasKey('category', $plugin0);
+        $this->assertArrayHasKey('active', $plugin0);
+
+        $this->assertEquals('plugin1', $plugin0['id']);
+        $this->assertEquals('taoQtiTest/previewer/plugins/plugin1', $plugin0['module']);
+        $this->assertEquals('taoQtiTest/loader/qtiPlugins.min', $plugin0['bundle']);
+        $this->assertEquals('previewer', $plugin0['category']);
+        $this->assertEquals(true, $plugin0['active']);
+
+        $this->assertArrayHasKey('1', $plugins);
+        $plugin1 = $plugins[1];
+        $this->assertArrayHasKey('id', $plugin1);
+        $this->assertArrayHasKey('module', $plugin1);
+        $this->assertArrayHasKey('bundle', $plugin1);
+        $this->assertArrayHasKey('category', $plugin1);
+        $this->assertArrayHasKey('active', $plugin1);
+
+        $this->assertEquals('plugin2', $plugin1['id']);
+        $this->assertEquals('taoQtiTest/previewer/plugins/plugin2', $plugin1['module']);
+        $this->assertEquals('taoQtiTest/loader/qtiPlugins.min', $plugin1['bundle']);
+        $this->assertEquals('previewer', $plugin1['category']);
+        $this->assertEquals(false, $plugin1['active']);
+    }
+
+    /**
      * Test the method ItemPreviewerService::registerAdapter
      */
     public function testRegisterAdapter()
@@ -200,7 +272,7 @@ class ItemPreviewerServiceTest extends TestCase
 
         $this->assertArrayHasKey('taoQtiTest/previewer/adapter/qtiItem', $adapters);
         $this->assertArrayHasKey('taoQtiTest/previewer/adapter/qtiTest', $adapters);
-        
+
         $this->assertEquals(true, $itemPreviewerService->unregisterAdapter('taoQtiTest/previewer/adapter/qtiTest'));
 
         $adapters = $itemPreviewerService->getAdapters();
@@ -209,5 +281,108 @@ class ItemPreviewerServiceTest extends TestCase
         $this->assertArrayNotHasKey('taoQtiTest/previewer/adapter/qtiTest', $adapters);
 
         $this->assertEquals(false, $itemPreviewerService->unregisterAdapter('taoQtiTest/previewer/adapter/qtiTest'));
+    }
+
+    /**
+     * Test the method ItemPreviewerService::registerPlugin
+     */
+    public function testRegisterPlugin()
+    {
+        $itemPreviewerService = $this->getItemPreviewerService();
+
+        $plugins = $itemPreviewerService->getPlugins();
+
+        $this->assertEquals(2, count($plugins));
+
+        $this->assertArrayHasKey('0', $plugins);
+        $this->assertArrayHasKey('id', $plugins[0]);
+        $this->assertEquals('plugin1', $plugins[0]['id']);
+
+        $this->assertArrayHasKey('1', $plugins);
+        $this->assertArrayHasKey('id', $plugins[1]);
+        $this->assertEquals('plugin2', $plugins[1]['id']);
+
+        $this->assertArrayNotHasKey('2', $plugins);
+
+        $module = DynamicModule::fromArray(
+            [
+                'id' => 'plugin3',
+                'module' => 'taoQtiTest/previewer/plugins/plugin3',
+                'bundle' => 'taoQtiTest/loader/qtiPlugins.min',
+                'name' => 'Plugin 3',
+                'description' => 'Sample plugin 3',
+                'category' => 'previewer',
+                'active' => true,
+                'tags' => []
+            ]
+        );
+        $this->assertEquals(true, $itemPreviewerService->registerPlugin($module));
+
+        $plugins = $itemPreviewerService->getPlugins();
+        $this->assertEquals(3, count($plugins));
+
+        $this->assertArrayHasKey('0', $plugins);
+        $this->assertArrayHasKey('id', $plugins[0]);
+        $this->assertEquals('plugin1', $plugins[0]['id']);
+
+        $this->assertArrayHasKey('1', $plugins);
+        $this->assertArrayHasKey('id', $plugins[1]);
+        $this->assertEquals('plugin2', $plugins[1]['id']);
+
+        $this->assertArrayHasKey('2', $plugins);
+        $this->assertArrayHasKey('id', $plugins[2]);
+        $this->assertEquals('plugin3', $plugins[2]['id']);
+
+        $module = DynamicModule::fromArray(
+            [
+                'id' => 'plugin3bis',
+                'module' => 'taoQtiTest/previewer/plugins/plugin3',
+                'bundle' => 'taoQtiTest/loader/qtiPlugins.min',
+                'name' => 'Plugin 3 bis',
+                'description' => 'Sample plugin 3',
+                'category' => 'previewer',
+                'active' => true,
+                'tags' => []
+            ]
+        );
+        $this->assertEquals(true, $itemPreviewerService->registerPlugin($module));
+
+        $plugins = $itemPreviewerService->getPlugins();
+        $this->assertEquals(3, count($plugins));
+        $this->assertArrayHasKey('2', $plugins);
+        $this->assertArrayHasKey('id', $plugins[2]);
+        $this->assertEquals('plugin3bis', $plugins[2]['id']);
+    }
+
+    /**
+     * Test the method ItemPreviewerService::unregisterPlugin
+     */
+    public function testUnregisterPlugin()
+    {
+        $itemPreviewerService = $this->getItemPreviewerService();
+
+        $plugins = $itemPreviewerService->getPlugins();
+
+        $this->assertEquals(2, count($plugins));
+
+        $this->assertArrayHasKey('0', $plugins);
+        $this->assertArrayHasKey('id', $plugins[0]);
+        $this->assertEquals('plugin1', $plugins[0]['id']);
+
+        $this->assertArrayHasKey('1', $plugins);
+        $this->assertArrayHasKey('id', $plugins[1]);
+        $this->assertEquals('plugin2', $plugins[1]['id']);
+
+        $this->assertEquals(true, $itemPreviewerService->unregisterPlugin('taoQtiTest/previewer/plugins/plugin2'));
+
+        $plugins = $itemPreviewerService->getPlugins();
+        $this->assertEquals(1, count($plugins));
+        $this->assertArrayHasKey('0', $plugins);
+        $this->assertArrayHasKey('id', $plugins[0]);
+        $this->assertEquals('plugin1', $plugins[0]['id']);
+
+        $this->assertArrayNotHasKey('1', $plugins);
+
+        $this->assertEquals(false, $itemPreviewerService->unregisterPlugin('taoQtiTest/previewer/plugins/plugin2'));
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CGA-97

Add the ability to register plugins for the Item Previewer.
The service `ItemPreviewerService` has been extented with these API:
- `getPlugins()`: get the list of registered plugins
- `registerPlugin($module)`: add a plugin to the registry
- `unregisterPlugin($module)`: remove a plugin from the registry

Unit test updated: `taoItems/test/unit/preview/ItemPreviewerServiceTest.php`

To run tests: `vendor/phpunit/phpunit/phpunit taoItems/test/unit/preview/ItemPreviewerServiceTest.php`

Note: this PR is targeted for sprint 127, another one will be created to bring the feature in the current sprint