### PR TITLE
Feature/CGA-97/Allow registering item previewer plugins

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -38,7 +38,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.9.0',
+    'version' => '10.10.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/preview/ItemPreviewerService.php
+++ b/models/classes/preview/ItemPreviewerService.php
@@ -101,7 +101,7 @@ class ItemPreviewerService extends ConfigurableService
      * @param DynamicModule $module the adapter to register
      * @return boolean true if registered
      */
-    public function registerAdapter(DynamicModule $module)
+    public function registerAdapter(DynamicModule $module): bool
     {
         if (!is_null($module) && ! empty($module->getModule())) {
             $registry = $this->getRegistry();
@@ -122,7 +122,7 @@ class ItemPreviewerService extends ConfigurableService
      * @param string $moduleId
      * @return boolean true if unregistered
      */
-    public function unregisterAdapter($moduleId)
+    public function unregisterAdapter($moduleId): bool
     {
 
         $registry = $this->getRegistry();
@@ -144,7 +144,7 @@ class ItemPreviewerService extends ConfigurableService
      * @param DynamicModule $module the plugin to register
      * @return boolean true if registered
      */
-    public function registerPlugin(DynamicModule $module)
+    public function registerPlugin(DynamicModule $module): bool
     {
         if (!is_null($module) && !empty($module->getModule())) {
             $registry = $this->getRegistry();
@@ -173,7 +173,7 @@ class ItemPreviewerService extends ConfigurableService
      * @param string $moduleId
      * @return boolean true if unregistered
      */
-    public function unregisterPlugin($moduleId)
+    public function unregisterPlugin($moduleId): bool
     {
         $registry = $this->getRegistry();
         $config = [];

--- a/models/classes/preview/ItemPreviewerService.php
+++ b/models/classes/preview/ItemPreviewerService.php
@@ -103,18 +103,19 @@ class ItemPreviewerService extends ConfigurableService
      */
     public function registerAdapter(DynamicModule $module): bool
     {
-        if (!is_null($module) && ! empty($module->getModule())) {
-            $registry = $this->getRegistry();
-            $config = [];
-            if ($registry->isRegistered(self::REGISTRY_ENTRY_KEY)) {
-                $config = $registry->get(self::REGISTRY_ENTRY_KEY);
-            }
-
-            $config[self::PREVIEWERS_KEY][$module->getModule()] = $module->toArray();
-            $registry->set(self::REGISTRY_ENTRY_KEY, $config);
-            return true;
+        if (null === $module || empty($module->getModule())) {
+            return false;
         }
-        return false;
+        
+        $registry = $this->getRegistry();
+        $config = [];
+        if ($registry->isRegistered(self::REGISTRY_ENTRY_KEY)) {
+            $config = $registry->get(self::REGISTRY_ENTRY_KEY);
+        }
+
+        $config[self::PREVIEWERS_KEY][$module->getModule()] = $module->toArray();
+        $registry->set(self::REGISTRY_ENTRY_KEY, $config);
+        return true;
     }
 
     /**
@@ -124,7 +125,6 @@ class ItemPreviewerService extends ConfigurableService
      */
     public function unregisterAdapter($moduleId): bool
     {
-
         $registry = $this->getRegistry();
         $config = [];
         if ($registry->isRegistered(self::REGISTRY_ENTRY_KEY)) {
@@ -146,26 +146,27 @@ class ItemPreviewerService extends ConfigurableService
      */
     public function registerPlugin(DynamicModule $module): bool
     {
-        if (!is_null($module) && !empty($module->getModule())) {
-            $registry = $this->getRegistry();
-            $config = [];
-            if ($registry->isRegistered(self::REGISTRY_ENTRY_KEY)) {
-                $config = $registry->get(self::REGISTRY_ENTRY_KEY);
-            }
-
-            $index = false;
-            if (isset($config[self::PLUGINS_KEY])) {
-                $index = array_search($module->getModule(), array_column($config[self::PLUGINS_KEY], 'module'));
-            }
-            if ($index === false) {
-                $config[self::PLUGINS_KEY][] = $module->toArray();
-            } else {
-                $config[self::PLUGINS_KEY][$index] = $module->toArray();
-            }
-            $registry->set(self::REGISTRY_ENTRY_KEY, $config);
-            return true;
+        if (null === $module || empty($module->getModule())) {
+            return false;
         }
-        return false;
+        
+        $registry = $this->getRegistry();
+        $config = [];
+        if ($registry->isRegistered(self::REGISTRY_ENTRY_KEY)) {
+            $config = $registry->get(self::REGISTRY_ENTRY_KEY);
+        }
+
+        $index = false;
+        if (isset($config[self::PLUGINS_KEY])) {
+            $index = array_search($module->getModule(), array_column($config[self::PLUGINS_KEY], 'module'));
+        }
+        if ($index === false) {
+            $config[self::PLUGINS_KEY][] = $module->toArray();
+        } else {
+            $config[self::PLUGINS_KEY][$index] = $module->toArray();
+        }
+        $registry->set(self::REGISTRY_ENTRY_KEY, $config);
+        return true;
     }
 
     /**

--- a/models/classes/preview/ItemPreviewerService.php
+++ b/models/classes/preview/ItemPreviewerService.php
@@ -186,7 +186,7 @@ class ItemPreviewerService extends ConfigurableService
         if (isset($config[self::PLUGINS_KEY])) {
             $config[self::PLUGINS_KEY] = array_filter(
                 $config[self::PLUGINS_KEY],
-                function ($plugin) use ($moduleId, &$result) {
+                static function (array $plugin) use ($moduleId, &$result): bool {
                     $result = $plugin['module'] == $moduleId;
                     return !$result;
                 }

--- a/models/classes/preview/ItemPreviewerService.php
+++ b/models/classes/preview/ItemPreviewerService.php
@@ -72,10 +72,7 @@ class ItemPreviewerService extends ConfigurableService
             $config = $registry->get(self::REGISTRY_ENTRY_KEY);
         }
 
-        if (isset($config[self::PREVIEWERS_KEY])) {
-            return $config[self::PREVIEWERS_KEY];
-        }
-        return [];
+        return $config[self::PREVIEWERS_KEY] ?? [];
     }
 
     /**
@@ -90,10 +87,7 @@ class ItemPreviewerService extends ConfigurableService
             $config = $registry->get(self::REGISTRY_ENTRY_KEY);
         }
 
-        if (isset($config[self::PLUGINS_KEY])) {
-            return $config[self::PLUGINS_KEY];
-        }
-        return [];
+        return $config[self::PLUGINS_KEY] ?? [];
     }
 
     /**

--- a/models/classes/preview/ItemPreviewerService.php
+++ b/models/classes/preview/ItemPreviewerService.php
@@ -33,9 +33,9 @@ use oat\tao\model\modules\DynamicModule;
 class ItemPreviewerService extends ConfigurableService
 {
     const SERVICE_ID = 'taoItems/ItemPreviewer';
-    const REGISTRY_ENTRY_KEY = 'taoItems/previewer/factory';
-    const PREVIEWERS_KEY = 'previewers';
-    const PLUGINS_KEY = 'plugins';
+    private const REGISTRY_ENTRY_KEY = 'taoItems/previewer/factory';
+    private const PREVIEWERS_KEY = 'previewers';
+    private const PLUGINS_KEY = 'plugins';
 
     private $registry;
 

--- a/models/classes/preview/ItemPreviewerService.php
+++ b/models/classes/preview/ItemPreviewerService.php
@@ -143,14 +143,15 @@ class ItemPreviewerService extends ConfigurableService
         if (null === $module || empty($module->getModule())) {
             return false;
         }
+
+        $this->unregisterPlugin($module->getModule());
         
         $registry = $this->getRegistry();
         $config = [];
         if ($registry->isRegistered(self::REGISTRY_ENTRY_KEY)) {
             $config = $registry->get(self::REGISTRY_ENTRY_KEY);
         }
-
-        $this->unregisterPlugin($module->getModule());
+        
         $config[self::PLUGINS_KEY][] = $module->toArray();
         $registry->set(self::REGISTRY_ENTRY_KEY, $config);
         return true;

--- a/models/classes/preview/ItemPreviewerService.php
+++ b/models/classes/preview/ItemPreviewerService.php
@@ -150,15 +150,8 @@ class ItemPreviewerService extends ConfigurableService
             $config = $registry->get(self::REGISTRY_ENTRY_KEY);
         }
 
-        $index = false;
-        if (isset($config[self::PLUGINS_KEY])) {
-            $index = array_search($module->getModule(), array_column($config[self::PLUGINS_KEY], 'module'));
-        }
-        if ($index === false) {
-            $config[self::PLUGINS_KEY][] = $module->toArray();
-        } else {
-            $config[self::PLUGINS_KEY][$index] = $module->toArray();
-        }
+        $this->unregisterPlugin($module->getModule());
+        $config[self::PLUGINS_KEY][] = $module->toArray();
         $registry->set(self::REGISTRY_ENTRY_KEY, $config);
         return true;
     }

--- a/test/unit/preview/ItemPreviewerServiceTest.php
+++ b/test/unit/preview/ItemPreviewerServiceTest.php
@@ -72,6 +72,38 @@ class ItemPreviewerServiceTest extends TestCase
                         'previewer'
                     ]
                 ]
+            ],
+            'plugins' => [
+                [
+                    'id' => 'plugin1',
+                    'module' => 'taoQtiTest/previewer/plugins/plugin1',
+                    'bundle' => 'taoQtiTest/loader/qtiPlugins.min',
+                    'position' => null,
+                    'name' => 'Plugin 1',
+                    'description' => 'Sample plugin 1',
+                    'category' => 'previewer',
+                    'active' => true,
+                    'tags' => [
+                        'core',
+                        'qti',
+                        'previewer'
+                    ]
+                ],
+                [
+                    'id' => 'plugin2',
+                    'module' => 'taoQtiTest/previewer/plugins/plugin2',
+                    'bundle' => 'taoQtiTest/loader/qtiPlugins.min',
+                    'position' => null,
+                    'name' => 'Plugin 2',
+                    'description' => 'Sample plugin 2',
+                    'category' => 'previewer',
+                    'active' => false,
+                    'tags' => [
+                        'core',
+                        'qti',
+                        'previewer'
+                    ]
+                ]
             ]
         ]
     ];
@@ -153,6 +185,46 @@ class ItemPreviewerServiceTest extends TestCase
     }
 
     /**
+     * Test the method ItemPreviewerService::getPlugins
+     */
+    public function testGetPlugins()
+    {
+        $itemPreviewerService = $this->getItemPreviewerService();
+
+        $plugins = $itemPreviewerService->getPlugins();
+
+        $this->assertEquals(2, count($plugins));
+
+        $this->assertArrayHasKey('0', $plugins);
+        $plugin0 = $plugins[0];
+        $this->assertArrayHasKey('id', $plugin0);
+        $this->assertArrayHasKey('module', $plugin0);
+        $this->assertArrayHasKey('bundle', $plugin0);
+        $this->assertArrayHasKey('category', $plugin0);
+        $this->assertArrayHasKey('active', $plugin0);
+
+        $this->assertEquals('plugin1', $plugin0['id']);
+        $this->assertEquals('taoQtiTest/previewer/plugins/plugin1', $plugin0['module']);
+        $this->assertEquals('taoQtiTest/loader/qtiPlugins.min', $plugin0['bundle']);
+        $this->assertEquals('previewer', $plugin0['category']);
+        $this->assertEquals(true, $plugin0['active']);
+
+        $this->assertArrayHasKey('1', $plugins);
+        $plugin1 = $plugins[1];
+        $this->assertArrayHasKey('id', $plugin1);
+        $this->assertArrayHasKey('module', $plugin1);
+        $this->assertArrayHasKey('bundle', $plugin1);
+        $this->assertArrayHasKey('category', $plugin1);
+        $this->assertArrayHasKey('active', $plugin1);
+
+        $this->assertEquals('plugin2', $plugin1['id']);
+        $this->assertEquals('taoQtiTest/previewer/plugins/plugin2', $plugin1['module']);
+        $this->assertEquals('taoQtiTest/loader/qtiPlugins.min', $plugin1['bundle']);
+        $this->assertEquals('previewer', $plugin1['category']);
+        $this->assertEquals(false, $plugin1['active']);
+    }
+
+    /**
      * Test the method ItemPreviewerService::registerAdapter
      */
     public function testRegisterAdapter()
@@ -200,7 +272,7 @@ class ItemPreviewerServiceTest extends TestCase
 
         $this->assertArrayHasKey('taoQtiTest/previewer/adapter/qtiItem', $adapters);
         $this->assertArrayHasKey('taoQtiTest/previewer/adapter/qtiTest', $adapters);
-        
+
         $this->assertEquals(true, $itemPreviewerService->unregisterAdapter('taoQtiTest/previewer/adapter/qtiTest'));
 
         $adapters = $itemPreviewerService->getAdapters();
@@ -209,5 +281,108 @@ class ItemPreviewerServiceTest extends TestCase
         $this->assertArrayNotHasKey('taoQtiTest/previewer/adapter/qtiTest', $adapters);
 
         $this->assertEquals(false, $itemPreviewerService->unregisterAdapter('taoQtiTest/previewer/adapter/qtiTest'));
+    }
+
+    /**
+     * Test the method ItemPreviewerService::registerPlugin
+     */
+    public function testRegisterPlugin()
+    {
+        $itemPreviewerService = $this->getItemPreviewerService();
+
+        $plugins = $itemPreviewerService->getPlugins();
+
+        $this->assertEquals(2, count($plugins));
+
+        $this->assertArrayHasKey('0', $plugins);
+        $this->assertArrayHasKey('id', $plugins[0]);
+        $this->assertEquals('plugin1', $plugins[0]['id']);
+
+        $this->assertArrayHasKey('1', $plugins);
+        $this->assertArrayHasKey('id', $plugins[1]);
+        $this->assertEquals('plugin2', $plugins[1]['id']);
+
+        $this->assertArrayNotHasKey('2', $plugins);
+
+        $module = DynamicModule::fromArray(
+            [
+                'id' => 'plugin3',
+                'module' => 'taoQtiTest/previewer/plugins/plugin3',
+                'bundle' => 'taoQtiTest/loader/qtiPlugins.min',
+                'name' => 'Plugin 3',
+                'description' => 'Sample plugin 3',
+                'category' => 'previewer',
+                'active' => true,
+                'tags' => []
+            ]
+        );
+        $this->assertEquals(true, $itemPreviewerService->registerPlugin($module));
+
+        $plugins = $itemPreviewerService->getPlugins();
+        $this->assertEquals(3, count($plugins));
+
+        $this->assertArrayHasKey('0', $plugins);
+        $this->assertArrayHasKey('id', $plugins[0]);
+        $this->assertEquals('plugin1', $plugins[0]['id']);
+
+        $this->assertArrayHasKey('1', $plugins);
+        $this->assertArrayHasKey('id', $plugins[1]);
+        $this->assertEquals('plugin2', $plugins[1]['id']);
+
+        $this->assertArrayHasKey('2', $plugins);
+        $this->assertArrayHasKey('id', $plugins[2]);
+        $this->assertEquals('plugin3', $plugins[2]['id']);
+
+        $module = DynamicModule::fromArray(
+            [
+                'id' => 'plugin3bis',
+                'module' => 'taoQtiTest/previewer/plugins/plugin3',
+                'bundle' => 'taoQtiTest/loader/qtiPlugins.min',
+                'name' => 'Plugin 3 bis',
+                'description' => 'Sample plugin 3',
+                'category' => 'previewer',
+                'active' => true,
+                'tags' => []
+            ]
+        );
+        $this->assertEquals(true, $itemPreviewerService->registerPlugin($module));
+
+        $plugins = $itemPreviewerService->getPlugins();
+        $this->assertEquals(3, count($plugins));
+        $this->assertArrayHasKey('2', $plugins);
+        $this->assertArrayHasKey('id', $plugins[2]);
+        $this->assertEquals('plugin3bis', $plugins[2]['id']);
+    }
+
+    /**
+     * Test the method ItemPreviewerService::unregisterPlugin
+     */
+    public function testUnregisterPlugin()
+    {
+        $itemPreviewerService = $this->getItemPreviewerService();
+
+        $plugins = $itemPreviewerService->getPlugins();
+
+        $this->assertEquals(2, count($plugins));
+
+        $this->assertArrayHasKey('0', $plugins);
+        $this->assertArrayHasKey('id', $plugins[0]);
+        $this->assertEquals('plugin1', $plugins[0]['id']);
+
+        $this->assertArrayHasKey('1', $plugins);
+        $this->assertArrayHasKey('id', $plugins[1]);
+        $this->assertEquals('plugin2', $plugins[1]['id']);
+
+        $this->assertEquals(true, $itemPreviewerService->unregisterPlugin('taoQtiTest/previewer/plugins/plugin2'));
+
+        $plugins = $itemPreviewerService->getPlugins();
+        $this->assertEquals(1, count($plugins));
+        $this->assertArrayHasKey('0', $plugins);
+        $this->assertArrayHasKey('id', $plugins[0]);
+        $this->assertEquals('plugin1', $plugins[0]['id']);
+
+        $this->assertArrayNotHasKey('1', $plugins);
+
+        $this->assertEquals(false, $itemPreviewerService->unregisterPlugin('taoQtiTest/previewer/plugins/plugin2'));
     }
 }


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CGA-97

Add the ability to register plugins for the Item Previewer.
The service `ItemPreviewerService` has been extented with these API:
- `getPlugins()`: get the list of registered plugins
- `registerPlugin($module)`: add a plugin to the registry
- `unregisterPlugin($module)`: remove a plugin from the registry

Unit test updated: `taoItems/test/unit/preview/ItemPreviewerServiceTest.php`

To run tests: `vendor/phpunit/phpunit/phpunit taoItems/test/unit/preview/ItemPreviewerServiceTest.php`
