### PR TITLE
Fix nex 1860/allow pdf assets to be packed on delivery compilation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.12.0',
+    'version' => '10.13.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/pack/ItemPack.php
+++ b/models/classes/pack/ItemPack.php
@@ -23,15 +23,15 @@ declare(strict_types=1);
 
 namespace oat\taoItems\model\pack;
 
+use InvalidArgumentException;
+use JsonSerializable;
 use LogicException;
-use \JsonSerializable;
 use oat\tao\helpers\Base64;
-use \InvalidArgumentException;
 use oat\tao\model\media\MediaAsset;
-use oat\taoMediaManager\model\MediaSource;
 use oat\tao\model\media\sourceStrategy\HttpSource;
-use tao_models_classes_service_StorageDirectory as StorageDirectory;
+use oat\taoMediaManager\model\MediaSource;
 use tao_models_classes_FileNotFoundException as FileNotFoundException;
+use tao_models_classes_service_StorageDirectory as StorageDirectory;
 
 /**
  * The Item Pack represents the item package data produced by the compilation.
@@ -41,7 +41,6 @@ use tao_models_classes_FileNotFoundException as FileNotFoundException;
  */
 class ItemPack implements JsonSerializable
 {
-
     /**
      * The supported assets types
      * @var string[]
@@ -59,7 +58,6 @@ class ItemPack implements JsonSerializable
         'apip',
         'pdf'
     ];
-
 
     /**
      * The item type
@@ -85,15 +83,15 @@ class ItemPack implements JsonSerializable
      * @var array
      */
     protected $assetEncoders = [
-        'html'     => 'none',
-        'document'     => 'none',
-        'js'        => 'none',
-        'css'       => 'none',
-        'font'      => 'none',
-        'img'       => 'none',
-        'audio'     => 'none',
-        'video'     => 'none',
-        'xinclude'  => 'none',
+        'html' => 'none',
+        'document' => 'none',
+        'js' => 'none',
+        'css' => 'none',
+        'font' => 'none',
+        'img' => 'none',
+        'audio' => 'none',
+        'video' => 'none',
+        'xinclude' => 'none',
         'apip' => 'none',
         'pdf' => 'none',
     ];
@@ -128,7 +126,7 @@ class ItemPack implements JsonSerializable
      * Get the item type
      * @return string the type
      */
-    public function getType()
+    public function getType(): string
     {
         return $this->type;
     }
@@ -137,13 +135,18 @@ class ItemPack implements JsonSerializable
      * Get the item data
      * @return array the data
      */
-    public function getData()
+    public function getData(): array
     {
         return $this->data;
     }
 
     /**
      * Set item's assets of a given type to the pack.
+     *
+     * @param string $type
+     * @param $assets
+     * @param StorageDirectory|null $publicDirectory
+     * @param bool $skipBinaries
      *
      * @throws ExceptionMissingEncoder
      * @throws FileNotFoundException
@@ -155,7 +158,7 @@ class ItemPack implements JsonSerializable
         bool $skipBinaries = false
     ): void {
         if (!is_array($assets)) {
-            throw new InvalidArgumentException('Assests should be an array, "' . gettype($assets) . '" given');
+            throw new InvalidArgumentException('Assets should be an array, "' . gettype($assets) . '" given');
         }
 
         foreach ($assets as $asset) {
@@ -164,6 +167,11 @@ class ItemPack implements JsonSerializable
     }
 
     /**
+     * @param string $type
+     * @param $asset
+     * @param StorageDirectory|null $publicDirectory
+     * @param bool $skipBinaries
+     *
      * @throws ExceptionMissingEncoder
      * @throws FileNotFoundException
      */
@@ -195,7 +203,7 @@ class ItemPack implements JsonSerializable
      * @param string $type the assets type, one of those who are supported
      * @return string[] the list of assets' URL to load
      */
-    public function getAssets($type)
+    public function getAssets(string $type): array
     {
         if (!array_key_exists($type, $this->assets)) {
             return [];
@@ -218,7 +226,7 @@ class ItemPack implements JsonSerializable
     /**
      * @return array
      */
-    public function getAssetEncoders()
+    public function getAssetEncoders(): array
     {
         return $this->assetEncoders;
     }
@@ -226,7 +234,7 @@ class ItemPack implements JsonSerializable
     /**
      * @param array $assetEncoders
      */
-    public function setAssetEncoders($assetEncoders)
+    public function setAssetEncoders(array $assetEncoders): void
     {
         foreach ($assetEncoders as $type => $encoder) {
             if ($encoder == '') {
@@ -240,7 +248,7 @@ class ItemPack implements JsonSerializable
     /**
      * @return boolean
      */
-    public function isNestedResourcesInclusion()
+    public function isNestedResourcesInclusion(): bool
     {
         return $this->nestedResourcesInclusion;
     }
@@ -248,7 +256,7 @@ class ItemPack implements JsonSerializable
     /**
      * @param boolean $nestedResourcesInclusion
      */
-    public function setNestedResourcesInclusion($nestedResourcesInclusion)
+    public function setNestedResourcesInclusion(bool $nestedResourcesInclusion): void
     {
         $this->nestedResourcesInclusion = (bool)$nestedResourcesInclusion;
     }

--- a/models/classes/pack/ItemPack.php
+++ b/models/classes/pack/ItemPack.php
@@ -46,7 +46,19 @@ class ItemPack implements JsonSerializable
      * The supported assets types
      * @var string[]
      */
-    private static $assetTypes = ['html', 'document', 'js', 'css', 'font', 'img', 'audio', 'video', 'xinclude', 'apip'];
+    private static $assetTypes = [
+        'html',
+        'document',
+        'js',
+        'css',
+        'font',
+        'img',
+        'audio',
+        'video',
+        'xinclude',
+        'apip',
+        'pdf'
+    ];
 
 
     /**
@@ -83,6 +95,7 @@ class ItemPack implements JsonSerializable
         'video'     => 'none',
         'xinclude'  => 'none',
         'apip' => 'none',
+        'pdf' => 'none',
     ];
 
     /**


### PR DESCRIPTION
Related to NEX-1860

Related PR: [extract-pdf-assets-on-export](https://github.com/oat-sa/extension-tao-itemqti/pull/1540)

**What is the issue**:
Having an item with any interaction that contains from Media asset import a PDF, we cannot export test or/and compile delivery.

**How to test.**

1. Install both this PR and the related one
2. Create an item with PDF media asset
3. Create a test with this item
4.
a) Export test
**Expected  behavior**: On export qti.xml of the item the PDF is reference as asset and not with taoMedia URI. On assets you can find the PDF.
b) Create a delivery
**Expected behavior**: The delivery is publishing successfully, Running the assessment the PDF is correctly presented




