### PR TITLE
UNO-277: Added InfoBox to the export form

### DIFF
--- a/actions/class.ItemExport.php
+++ b/actions/class.ItemExport.php
@@ -89,7 +89,7 @@ class taoItems_actions_ItemExport extends tao_actions_Export
         $formFactory = parent::getFormFactory($handlers, $exporter, $selectedResource, $formData);
         $instances = $this->getClassInstances();
         if (!count($instances)) {
-            $formFactory->setInfoBox('<b>Note</b>: For empty classes, the RDF format<br />is the only available format.');
+            $formFactory->setInfoBox(__('<b>Note</b>: For empty classes, the RDF format<br />is the only available format.'));
         }
         return $formFactory;
     }

--- a/manifest.php
+++ b/manifest.php
@@ -39,12 +39,12 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.14.0',
+    'version' => '10.15.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',
         'generis' => '>=12.5.0',
-        'tao' => '>=45.12.0',
+        'tao' => '>=46.4.0',
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAOItem.rdf',


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/UNO-277
 
Export button should not be clickable for a folder structure with no content / items
 
#### Steps to reproduce  (for bugs)
 - Create new Class in the Items section of the Backoffice
 - try to export this empty class (note that RDF export works - other exports don't work and some of them with error message)
  
#### How to test
 
Only RDF export should be shown for the classes/folders without items, and Notice provided:
![2020-10-22_10-14-49](https://user-images.githubusercontent.com/1445911/96861634-03a3f680-146d-11eb-9789-c9fd569fbe45.png)

Requires PR :
 - [x] https://github.com/oat-sa/tao-core/pull/2715