### PR TITLE
Feature/CON-12 Add dialogs with related test on item and itemClass deletion

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -36,10 +36,10 @@
                     <action id="item-class-new" name="New class" url="/taoItems/Items/addSubClass" context="resource" group="tree" binding="subClass">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="item-delete" name="Delete" url="/taoItems/Items/deleteItem" context="instance" group="tree" binding="removeNode" >
+                    <action id="item-delete" name="Delete" url="/taoItems/Items/deleteItem" context="instance" group="tree" binding="deleteItem" >
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="item-class-delete" name="Delete" url="/taoItems/Items/deleteClass" context="class" group="tree" binding="removeNode" >
+                    <action id="item-class-delete" name="Delete" url="/taoItems/Items/deleteClass" context="class" group="tree" binding="deleteItemClass" >
                         <icon id="icon-bin"/>
                     </action>
                     <action id="item-delete-all" name="Delete" url="/taoItems/Items/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes">

--- a/manifest.php
+++ b/manifest.php
@@ -44,7 +44,7 @@ return [
     'requires' => [
         'taoBackOffice' => '>=3.0.0',
         'generis' => '>=12.5.0',
-        'tao' => '>=46.4.0',
+        'tao' => '>=46.6.0',
     ],
     'models' => [
         'http://www.tao.lu/Ontologies/TAOItem.rdf',

--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.15.0',
+    'version' => '10.16.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -9,6 +9,7 @@ module.exports = function(grunt) {
     sass.taoitems = { };
     sass.taoitems.files = { };
     sass.taoitems.files[root + 'css/preview.css'] = root + 'scss/preview.scss';
+    sass.taoitems.files[root + 'js/controller/items/css/relatedTestsPopup.css'] = root + 'js/controller/items/scss/relatedTestsPopup.scss';
 
     watch.taoitemssass = {
         files : [root + 'scss/**/*.scss'],

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -18,19 +18,48 @@
  */
 define([
     'lodash',
+    'jquery',
+    'i18n',
     'module',
     'layout/actions/binder',
-    'taoItems/previewer/factory'
-], function(_,  module, binder, previewerFactory){
-	'use strict';
+    'taoItems/previewer/factory',
+    'core/request',
+    'ui/feedback',
+    'ui/dialog/confirm',
+    'ui/dialog/alert',
+    'ui/dialog/confirmDelete',
+    'util/url',
+    'uri',
+    'tpl!taoItems/controller/items/tpl/relatedTestsPopup',
+    'tpl!taoItems/controller/items/tpl/relatedClassTestsPopup',
+    'tpl!taoItems/controller/items/tpl/forbiddenClassAction',
+], function (
+    _,
+    $,
+    __,
+    module,
+    binder,
+    previewerFactory,
+    request,
+    feedback,
+    confirmDialog,
+    alertDialog,
+    confirmDeleteDialog,
+    urlUtil,
+    uri,
+    relatedTestsPopupTpl,
+    relatedClassTestsPopupTpl,
+    forbiddenClassActionTpl
+) {
+    'use strict';
 
     binder.register('itemPreview', function itemPreview(actionContext) {
         var defaultConfig = {
             itemType: 'qtiItem', // TODO: field name can be changed after backend fix (for getting itemType from config )
-            state: { },
+            state: {},
             uri: {
-                itemUri: actionContext.id,
-            },
+                itemUri: actionContext.id
+            }
         };
         var config = _.merge(defaultConfig, module.config());
 
@@ -38,6 +67,115 @@ define([
             readOnly: false,
             fullPage: true
         });
-	});
+    });
 
+    binder.register('deleteItem', function (actionContext) {
+        return new Promise((resolve, reject) => {
+            checkRelations({
+                sourceId: actionContext.id
+            })
+            .then((responseRelated) => {
+                const relatedTests = responseRelated.data;
+                const name = $('a.clicked', actionContext.tree).text().trim();
+                if (relatedTests.length === 0) {
+                    confirmDialog(
+                        `${__('Are you sure you want to delete the item')} <b>${name}</b>?`,
+                        () => accept(actionContext, this.url, resolve, reject),
+                        () => cancel(reject)
+                    );
+                } else {
+                    confirmDeleteDialog(
+                        relatedTestsPopupTpl({
+                            name,
+                            number: relatedTests.length,
+                            tests: relatedTests
+                        }),
+                        () => accept(actionContext, this.url, resolve, reject),
+                        () => cancel(reject)
+                    );
+                }
+            });
+        });
+    });
+
+    binder.register('deleteItemClass', function (actionContext) {
+        return new Promise((resolve, reject) => {
+            checkRelations({
+                classId: actionContext.id
+            })
+            .then((responseRelated) => {
+                const relatedTests = responseRelated.data;
+                const name = $('a.clicked', actionContext.tree).text().trim();
+                if (relatedTests.length === 0) {
+                    confirmDeleteDialog(
+                        `${__('Are you sure you want to delete the class')} <b>${name}</b> ${__('and all of its content?')}`,
+                        () => accept(actionContext, this.url, resolve, reject),
+                        () => cancel(reject)
+                    );
+                } else {
+                    confirmDeleteDialog(
+                        relatedClassTestsPopupTpl({
+                            name,
+                            number: relatedTests.length,
+                            tests: relatedTests
+                        }),
+                        () => accept(actionContext, this.url, resolve, reject),
+                        () => cancel(reject)
+                    );
+                }
+            })
+            .catch(errorObject => {
+                if (errorObject.response.code === 999) {
+                    alertDialog(
+                        forbiddenClassActionTpl(),
+                        () => cancel(reject)
+                    );
+                }
+            });
+        });
+    });
+
+    function checkRelations(data) {
+        return request({
+            url: urlUtil.route('relations', 'MediaRelations', 'taoMediaManager'),
+            data,
+            method: 'GET',
+            noToken: true
+        });
+    }
+
+    function accept(actionContext, url, resolve, reject) {
+        return request({
+            url: url,
+            method: 'POST',
+            data: {
+                uri: uri.decode(actionContext.uri),
+                classUri: actionContext.classUri,
+                id: actionContext.id,
+                signature: actionContext.signature
+            },
+            dataType: 'json'
+        }).then(function (response) {
+            if (response.success && response.deleted) {
+                feedback().success(response.message || __('Resource deleted'));
+
+                if (actionContext.tree) {
+                    $(actionContext.tree).trigger('removenode.taotree', [
+                        {
+                            id: actionContext.uri || actionContext.classUri
+                        }
+                    ]);
+                }
+                return resolve({
+                    uri: actionContext.uri || actionContext.classUri
+                });
+            } else {
+                reject(response.msg || __('Unable to delete the selected resource'));
+            }
+        });
+    }
+
+    function cancel(reject) {
+        reject({ cancel: true });
+    }
 });

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -123,7 +123,10 @@ define([
                         relatedClassTestsPopupTpl({
                             name,
                             number: relatedTests.length,
-                            tests: relatedTests
+                            numberOther: relatedTests.length - 3 > 0 ? relatedTests.length - 3 : 0,
+                            tests: relatedTests.length <= 3 ? relatedTests : relatedTests.slice(0, 3),
+                            multiple:  relatedTests.length > 1,
+                            multipleOthers: relatedTests.length - 3 > 1,
                         }),
                         () => accept(actionContext, this.url, resolve, reject),
                         () => cancel(reject)

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -33,6 +33,7 @@ define([
     'tpl!taoItems/controller/items/tpl/relatedTestsPopup',
     'tpl!taoItems/controller/items/tpl/relatedClassTestsPopup',
     'tpl!taoItems/controller/items/tpl/forbiddenClassAction',
+    'css!taoItems/controller/items/css/relatedTestsPopup.css',
 ], function (
     _,
     $,
@@ -72,10 +73,11 @@ define([
     binder.register('deleteItem', function (actionContext) {
         return new Promise((resolve, reject) => {
             checkRelations({
-                sourceId: actionContext.id
+                sourceId: actionContext.id,
+                type: 'item'
             })
             .then((responseRelated) => {
-                const relatedTests = responseRelated.data;
+                const relatedTests = responseRelated.data.relations;
                 const name = $('a.clicked', actionContext.tree).text().trim();
                 if (relatedTests.length === 0) {
                     confirmDialog(
@@ -88,7 +90,10 @@ define([
                         relatedTestsPopupTpl({
                             name,
                             number: relatedTests.length,
-                            tests: relatedTests
+                            numberOther: relatedTests.length - 3 > 0 ? relatedTests.length - 3 : 0,
+                            tests: relatedTests.length <= 3 ? relatedTests : relatedTests.slice(0, 3),
+                            multiple:  relatedTests.length > 1,
+                            multipleOthers: relatedTests.length - 3 > 1,
                         }),
                         () => accept(actionContext, this.url, resolve, reject),
                         () => cancel(reject)
@@ -101,10 +106,11 @@ define([
     binder.register('deleteItemClass', function (actionContext) {
         return new Promise((resolve, reject) => {
             checkRelations({
-                classId: actionContext.id
+                classId: actionContext.id,
+                type: 'item'
             })
             .then((responseRelated) => {
-                const relatedTests = responseRelated.data;
+                const relatedTests = responseRelated.data.relations;
                 const name = $('a.clicked', actionContext.tree).text().trim();
                 if (relatedTests.length === 0) {
                     confirmDeleteDialog(
@@ -137,7 +143,7 @@ define([
 
     function checkRelations(data) {
         return request({
-            url: urlUtil.route('relations', 'MediaRelations', 'taoMediaManager'),
+            url: urlUtil.route('index', 'ResourceRelations', 'tao'),
             data,
             method: 'GET',
             noToken: true

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -30,6 +30,7 @@ define([
     'ui/dialog/confirmDelete',
     'util/url',
     'uri',
+    'util/wrapLongWords',
     'tpl!taoItems/controller/items/tpl/relatedTestsPopup',
     'tpl!taoItems/controller/items/tpl/relatedClassTestsPopup',
     'tpl!taoItems/controller/items/tpl/forbiddenClassAction',
@@ -48,6 +49,7 @@ define([
     confirmDeleteDialog,
     urlUtil,
     uri,
+    wrapLongWords,
     relatedTestsPopupTpl,
     relatedClassTestsPopupTpl,
     forbiddenClassActionTpl
@@ -78,7 +80,7 @@ define([
             })
             .then((responseRelated) => {
                 const relatedTests = responseRelated.data.relations;
-                const name = $('a.clicked', actionContext.tree).text().trim();
+                const name = prepareName($('a.clicked', actionContext.tree).text().trim());
                 if (relatedTests.length === 0) {
                     confirmDialog(
                         `${__('Are you sure you want to delete the item')} <b>${name}</b>?`,
@@ -111,7 +113,7 @@ define([
             })
             .then((responseRelated) => {
                 const relatedTests = responseRelated.data.relations;
-                const name = $('a.clicked', actionContext.tree).text().trim();
+                const name = prepareName($('a.clicked', actionContext.tree).text().trim());
                 if (relatedTests.length === 0) {
                     confirmDeleteDialog(
                         `${__('Are you sure you want to delete the class')} <b>${name}</b> ${__('and all of its content?')}`,
@@ -186,5 +188,13 @@ define([
 
     function cancel(reject) {
         reject({ cancel: true });
+    }
+
+    function prepareName(name) {
+        if (name.length < 50) {
+            return name;
+        } else {
+            return wrapLongWords(name, 50);
+        }
     }
 });

--- a/views/js/controller/items/css/relatedTestsPopup.css
+++ b/views/js/controller/items/css/relatedTestsPopup.css
@@ -1,0 +1,3 @@
+.preview-modal-feedback.modal .icon-warning{font-size:150%;position:relative;top:2px}.preview-modal-feedback.modal .gray-others{opacity:0.4}
+
+/*# sourceMappingURL=relatedTestsPopup.css.map */

--- a/views/js/controller/items/css/relatedTestsPopup.css.map
+++ b/views/js/controller/items/css/relatedTestsPopup.css.map
@@ -1,0 +1,9 @@
+{
+	"version": 3,
+	"file": "relatedTestsPopup.css",
+	"sources": [
+		"../scss/relatedTestsPopup.scss"
+	],
+	"names": [],
+	"mappings": "AAAA,AAEE,uBAFqB,AACrB,MAAM,CACN,aAAa,AAAC,CACb,SAAS,CAAE,IAAI,CACf,QAAQ,CAAE,QAAQ,CAClB,GAAG,CAAE,GAAG,CACR,AANH,AAOE,uBAPqB,AACrB,MAAM,CAMN,YAAY,AAAC,CACZ,OAAO,CAAE,GAAG,CACZ"
+}

--- a/views/js/controller/items/scss/relatedTestsPopup.scss
+++ b/views/js/controller/items/scss/relatedTestsPopup.scss
@@ -1,0 +1,12 @@
+.preview-modal-feedback {
+	&.modal{
+		.icon-warning {
+			font-size: 150%;
+			position: relative;
+			top: 2px;
+		}
+		.gray-others {
+			opacity: 0.4;
+		}
+	}
+}

--- a/views/js/controller/items/tpl/forbiddenClassAction.tpl
+++ b/views/js/controller/items/tpl/forbiddenClassAction.tpl
@@ -1,0 +1,3 @@
+<b>{{__ 'Forbidden action'}}</b><br><br>
+{{__ 'The class'}} <b>{{name}}</b> {{__ 'you are trying to delete is too large and contains too many subclasses.'}}<br>
+{{__ 'Please delete the subclasses before.'}}

--- a/views/js/controller/items/tpl/relatedClassTestsPopup.tpl
+++ b/views/js/controller/items/tpl/relatedClassTestsPopup.tpl
@@ -1,0 +1,4 @@
+<b>{{__ 'Warning'}}</b><br><br>
+{{__ 'You are about to delete the class'}} <b>{{name}}</b>, {{__ 'which contains assets that are in use elsewhere.'}}
+{{__ 'Deleting this class will break the items and the tests that are currently using them.'}}<br><br>
+{{__ 'Are you sure you want to delete this class and all of its content?'}}

--- a/views/js/controller/items/tpl/relatedClassTestsPopup.tpl
+++ b/views/js/controller/items/tpl/relatedClassTestsPopup.tpl
@@ -1,4 +1,11 @@
-<b>{{__ 'Warning'}}</b><br><br>
-{{__ 'You are about to delete the class'}} <b>{{name}}</b>, {{__ 'which contains assets that are in use elsewhere.'}}
-{{__ 'Deleting this class will break the items and the tests that are currently using them.'}}<br><br>
-{{__ 'Are you sure you want to delete this class and all of its content?'}}
+<span class="icon icon-warning"></span> <b>{{__ 'Warning'}}</b><br><br>
+{{__ 'The class'}} <b>{{name}}</b> {{__ 'contains content that is currently in use.'}}
+{{__ 'Deleting this class will break the'}} <b>{{number}}</b> {{__ 'test'}}{{#if multiple}}{{__ 's'}}{{/if}} {{__ 'using it:'}}
+<ul>
+{{#each tests}}<li>{{this.label}}</li>{{/each}}
+</ul>
+{{#if numberOther}}
+<span class="gray-others">{{__ 'and'}} {{numberOther}} {{__ 'other'}}{{#if multipleOthers}}{{__ 's'}}{{/if}}.</span><br><br>
+{{/if}}
+
+<b>{{__ 'Are you sure you want to delete this class and all of its content?'}}</b>

--- a/views/js/controller/items/tpl/relatedTestsPopup.tpl
+++ b/views/js/controller/items/tpl/relatedTestsPopup.tpl
@@ -1,0 +1,5 @@
+{{__ 'This'}} <b>{{name}}</b> {{__ 'is currently used in'}} {{number}} {{__ 'item(s)'}}:
+<ul>
+{{#each items}}<li>{{this.label}}</li>{{/each}}
+</ul>
+{{__ 'Are you sure you want to delete this'}} <b>{{name}}</b>?

--- a/views/js/controller/items/tpl/relatedTestsPopup.tpl
+++ b/views/js/controller/items/tpl/relatedTestsPopup.tpl
@@ -1,5 +1,11 @@
-{{__ 'This'}} <b>{{name}}</b> {{__ 'is currently used in'}} {{number}} {{__ 'item(s)'}}:
+<span class="icon icon-warning"></span> <b>{{__ 'Warning'}}</b><br><br>
+{{__ 'The item'}} <b>{{name}}</b> {{__ 'is currently in use.'}}
+{{__ 'Deleting this item will break the'}} <b>{{number}}</b> {{__ 'test'}}{{#if multiple}}{{__ 's'}}{{/if}} {{__ 'using it:'}}
 <ul>
-{{#each items}}<li>{{this.label}}</li>{{/each}}
+{{#each tests}}<li>{{this.label}}</li>{{/each}}
 </ul>
-{{__ 'Are you sure you want to delete this'}} <b>{{name}}</b>?
+{{#if numberOther}}
+<span class="gray-others">{{__ 'and'}} {{numberOther}} {{__ 'other'}}{{#if multipleOthers}}{{__ 's'}}{{/if}}.</span><br><br>
+{{/if}}
+
+<b>{{__ 'Are you sure you want to delete this item?'}}</b>


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-12
Related to 
https://github.com/oat-sa/tao-core-ui-fe/pull/204
https://github.com/oat-sa/extension-tao-mediamanager/pull/236
https://github.com/oat-sa/tao-core/pull/2721

How to test:
- go to Items page
- try to delete Item
- try to delete Class

Can be tested here http://item-delete_warning.playground.kitchen.it.taocloud.org:49591/

![image](https://user-images.githubusercontent.com/25976342/97896269-e8c36300-1d45-11eb-8bfc-ddb03784cbc5.png)
![image](https://user-images.githubusercontent.com/25976342/97896320-f842ac00-1d45-11eb-88b6-95cd20408777.png)
