### PR TITLE
Feature/CON-25/support Item Preview providers from module config

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -39,7 +39,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.16.1',
+    'version' => '10.17.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -57,12 +57,12 @@ define([
     'use strict';
 
     binder.register('itemPreview', function itemPreview(actionContext) {
-        var defaultConfig = {
+        const defaultConfig = {
             provider: 'qtiItem',
             state: {},
             uri: actionContext.id
         };
-        var config = _.merge(defaultConfig, module.config());
+        const config = _.merge(defaultConfig, module.config());
 
         previewerFactory(config.provider, config.uri, config.state, {
             readOnly: false,

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -58,15 +58,13 @@ define([
 
     binder.register('itemPreview', function itemPreview(actionContext) {
         var defaultConfig = {
-            itemType: 'qtiItem', // TODO: field name can be changed after backend fix (for getting itemType from config )
+            provider: 'qtiItem',
             state: {},
-            uri: {
-                itemUri: actionContext.id
-            }
+            uri: actionContext.id
         };
         var config = _.merge(defaultConfig, module.config());
 
-        previewerFactory(config.itemType, config.uri, config.state, {
+        previewerFactory(config.provider, config.uri, config.state, {
             readOnly: false,
             fullPage: true
         });


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/CON-25
https://github.com/oat-sa/extension-tao-testqti-previewer/pull/110
https://github.com/oat-sa/extension-tao-test-preview-ui-loader/pull/12
https://github.com/oat-sa/extension-tao-itemqti/pull/1585

Added support for Item Preview providers from `module.config `

How to test:
- go to page Items
- click Preview
- check that preview uses new UI
- go to Item Authoring page
- click Preview
- check that preview uses new UI
![image](https://user-images.githubusercontent.com/25976342/99570701-6395aa80-29e3-11eb-8832-13a1491e32c4.png)