### PR TITLE
Feature/CON-144/Add new class property to skip validation

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.18.2',
+    'version' => '10.19.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/pack/ItemPacker.php
+++ b/models/classes/pack/ItemPacker.php
@@ -49,10 +49,14 @@ abstract class ItemPacker
 
     protected $nestedResourcesInclusion;
 
-    public function __construct($assetEncoders = [], $nestedResourcesInclusion = true)
+    /** @var bool */
+    protected $skipValidation;
+
+    public function __construct($assetEncoders = [], $nestedResourcesInclusion = true, bool $skipValidation = false)
     {
         $this->assetEncoders = array_merge($this->assetEncoders, $assetEncoders);
         $this->nestedResourcesInclusion = $nestedResourcesInclusion;
+        $this->skipValidation = $skipValidation;
     }
 
     /**
@@ -109,5 +113,10 @@ abstract class ItemPacker
     public function setNestedResourcesInclusion($nestedResourcesInclusion)
     {
         $this->nestedResourcesInclusion = $nestedResourcesInclusion;
+    }
+
+    public function setSkipValidation(bool $skipValidation): void
+    {
+        $this->skipValidation = $skipValidation;
     }
 }

--- a/models/classes/pack/Packer.php
+++ b/models/classes/pack/Packer.php
@@ -58,17 +58,21 @@ class Packer implements ServiceLocatorAwareInterface
      */
     private $itemService;
 
+    /** @var bool */
+    private $skipValidation;
+
     /**
      * Create a packer for an item
      *
      * @param core_kernel_classes_Resource $item
      * @param string $lang
      */
-    public function __construct(core_kernel_classes_Resource $item, $lang = '')
+    public function __construct(core_kernel_classes_Resource $item, $lang = '', bool $skipValidation = false)
     {
         $this->item = $item;
         $this->lang = $lang;
         $this->itemService = taoItems_models_classes_ItemsService::singleton();
+        $this->skipValidation = $skipValidation;
     }
 
     /**
@@ -117,6 +121,7 @@ class Packer implements ServiceLocatorAwareInterface
 
             $itemPacker->setAssetEncoders($assetEncoders);
             $itemPacker->setNestedResourcesInclusion($nestedResourcesInclusion);
+            $itemPacker->setSkipValidation($this->skipValidation);
 
             //then create the pack
             $itemPack = $itemPacker->packItem($this->item, $this->lang, $this->getStorageDirectory());


### PR DESCRIPTION
**Relates to:** [CON-144](https://oat-sa.atlassian.net/browse/CON-144)

**Changes:**
* Added new class boolean property `$skipValidation`;
* Added new setter for class property `setSkipValidation`;
* Added new boolean argument `$skipValidation` with default `false` value to `__constructor`.

**Companion PRs:**
* [oat-sa/extension-tao-itemqti#1607](https://github.com/oat-sa/extension-tao-itemqti/pull/1607)
* [oat-sa/extension-tao-qtiprint#82](https://github.com/oat-sa/extension-tao-qtiprint/pull/82)
* [oat-sa/extension-tao-booklet#114](https://github.com/oat-sa/extension-tao-booklet/pull/114)