### PR TITLE
fix: safer resource disposal

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.19.0',
+    'version' => '10.19.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/models/classes/media/LocalItemSource.php
+++ b/models/classes/media/LocalItemSource.php
@@ -205,8 +205,9 @@ class LocalItemSource implements MediaManagement
 
         $file = $this->getItemDirectory()->getDirectory($parent)->getFile($fileName);
         $writeSuccess = $file->put($resource);
-        fclose($resource);
-
+        if (is_resource($resource)) {
+            fclose($resource);
+        }
         if (! $writeSuccess) {
             throw new \common_Exception('Unable to write file ("' . $fileName . '")');
         }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/CON-287

todo ( may have similar issues with tests), checkboxes bellow are not mandatory for the scope of current PR

- [x] Assets uploading to the local source ( closing streams issue )
- [ ] exports ( trying copying 'closed' streams )
- [ ] deletion ( dies on attempt to remove empty folders within data directories ) 