### PR TITLE
Fix [CON-203] - Color of arrowheads does not match with color of lines

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -40,7 +40,7 @@ return [
     'label' => 'Item core extension',
     'description' => 'TAO Items extension',
     'license' => 'GPL-2.0',
-    'version' => '10.19.0',
+    'version' => '10.19.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [
         'taoBackOffice' => '>=3.0.0',

--- a/views/package-lock.json
+++ b/views/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@oat-sa/tao-items",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@oat-sa/tao-item-runner": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.7.0.tgz",
-      "integrity": "sha512-ENKiAoxC5RsSXYafTa64FJXA53kgg2qVlK+CjfCnLbQIw/MTfxAQ/xSqTkrOaacI38L4OEoijz0aEIckrZEKkQ=="
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@oat-sa/tao-item-runner/-/tao-item-runner-0.7.1.tgz",
+      "integrity": "sha512-3+kd6sH5yckD9iH3+IDnmTHctT0dFUx55vFfhlo8LvzyaE77I6Eci0uyOQpoDUMqRTzyw7tABBkNue0WkfAAsw=="
     }
   }
 }

--- a/views/package.json
+++ b/views/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/tao-items",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "GPL-2.0",
   "description": "taoItems frontend modules",
   "repository": {
@@ -8,6 +8,6 @@
     "url": "git+https://github.com/oat-sa/extension-tao-items.git"
   },
   "dependencies": {
-    "@oat-sa/tao-item-runner": "0.7.0"
+    "@oat-sa/tao-item-runner": "0.7.1"
   }
 }


### PR DESCRIPTION
**Issue**

https://oat-sa.atlassian.net/browse/CON-203

**Related work**

https://github.com/oat-sa/extension-tao-itemqti/issues/1577

**Description**

The color of all arrowheads (including axis arrowheads) changes, when we change the current line or add new. So, it will always inherit the color from the last path created with the arrow-end/ arrow-start attribute set.
 
![imagen](https://user-images.githubusercontent.com/34692207/104584984-aed6dd00-5663-11eb-9173-732e4fc5c82c.png)

The full description of [issue](https://github.com/oat-sa/extension-tao-itemqti)/issues/1577

Also, it looks like the PCI settings are broken on the construct side. When trying to open Lines options an error pops up in the console.

![imagen](https://user-images.githubusercontent.com/34692207/104585059-ca41e800-5663-11eb-939c-19309c432365.png)

**AC**

- [x] Fix arrow head color
- [ ] Fix error in console of PCI settings