### PR TITLE
feat: create atomic roles for item class

### DIFF
--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -154,6 +154,15 @@ class taoItems_actions_Items extends tao_actions_SaSModule
     }
 
     /**
+     * view class label action
+     * @requiresRight classUri READ
+     */
+    public function viewClassLabel()
+    {
+        return parent::editClassLabel(true);
+    }
+
+    /**
      * edit an item instance
      * @requiresRight id READ
      */

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -18,7 +18,7 @@
                     />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="item-class-properties" name="Properties" url="/taoItems/Items/editClassLabel" group="content" context="class">
+                    <action id="item-class-properties" name="Properties" url="/taoItems/Items/viewClassLabel" group="content" context="class">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="item-class-schema" name="Manage Schema" url="/taoItems/Items/editItemClass" group="content" context="class">


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-154

- Created atomic roles for item classes (ItemClassNavigator, ItemClassEditor, ItemClassCreator) which include base BackOffice for being able to login
- Migration and install script
- Non-breaking fix in RdfController for proper division of access to view and edit methods In child controllers

How to test:

- Create users with atomic roles
- Log in and check that only specified in the task abilities are matched

Dependent PRs:

- [core](https://github.com/oat-sa/tao-core/pull/2852)
- [generis](https://github.com/oat-sa/generis/pull/896)