### PR TITLE
fix: prepare assets for preview in resource manager

### DIFF
--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -26,6 +26,7 @@ use oat\tao\model\http\ContentDetector;
 use oat\tao\model\http\HttpJsonResponseTrait;
 use oat\tao\model\media\MediaBrowser;
 use oat\tao\model\media\mediaSource\DirectorySearchQuery;
+use oat\tao\model\media\ProcessedFileStreamAware;
 use oat\taoItems\model\media\AssetTreeBuilder;
 use oat\taoItems\model\media\ItemMediaResolver;
 
@@ -205,9 +206,15 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
         $resolver = new ItemMediaResolver($item, $itemLang);
 
         $asset = $resolver->resolve($params['path']);
-        $stream = $asset->getMediaSource()->getFileStream($asset->getMediaIdentifier());
+        $mediaSource = $asset->getMediaSource();
 
-        $info = $asset->getMediaSource()->getFileInfo($asset->getMediaIdentifier());
+        if ($mediaSource instanceof ProcessedFileStreamAware) {
+            $stream = $mediaSource->getProcessedFileStream($asset->getMediaIdentifier());
+        } else {
+            $stream = $mediaSource->getFileStream($asset->getMediaIdentifier());
+        }
+
+        $info = $mediaSource->getFileInfo($asset->getMediaIdentifier());
 
         $mime = $info['mime'] !== 'application/qti+xml' ? $info['mime'] : null;
 

--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -53,7 +53,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
         $childrenOffset = (int)($params['childrenOffset'] ?? AssetTreeBuilder::DEFAULT_PAGINATION_OFFSET);
 
         $filters = $this->buildFilters($params);
-        $asset = $this->getMediaAssetByPSRQueryParams();
+        $asset = $this->getMediaAssetByPSRRequestQueryParams();
 
         $searchQuery = new DirectorySearchQuery(
             $asset,
@@ -74,7 +74,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
     public function fileExists(): void
     {
         try {
-            $asset = $this->getMediaAssetByPSRQueryParams();
+            $asset = $this->getMediaAssetByPSRRequestQueryParams();
             $asset->getMediaSource()->getFileInfo($asset->getMediaIdentifier());
             $found = true;
         } catch (FileNotFoundException $exception) {
@@ -177,7 +177,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
      */
     public function download(): void
     {
-        $asset = $this->getMediaAssetByPSRQueryParams();
+        $asset = $this->getMediaAssetByPSRRequestQueryParams();
         $mediaSource = $asset->getMediaSource();
         $stream = $this->getMediaSourceFileStream($mediaSource, $asset);
 
@@ -194,7 +194,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
      */
     public function delete(): void
     {
-        $asset = $this->getMediaAssetByPSRQueryParams();
+        $asset = $this->getMediaAssetByPSRRequestQueryParams();
         $deleted = $asset->getMediaSource()->delete($asset->getMediaIdentifier());
 
         $formatter = $this->getResponseFormatter()
@@ -206,7 +206,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
     /**
      * @throws MissingParameterException|TaoMediaException
      */
-    protected function getMediaAssetByPSRQueryParams(): MediaAsset
+    protected function getMediaAssetByPSRRequestQueryParams(): MediaAsset
     {
         $params = $this->getPsrRequest()->getQueryParams();
 


### PR DESCRIPTION
This PR solvea the bug with [failed to load an image in passage preview](https://oat-sa.atlassian.net/browse/AUT-28).
The preview window is in the media browser pop-up:
![image](https://user-images.githubusercontent.com/18700632/114677429-f88e9c80-9d12-11eb-89f9-db3aee758600.png)

***How to check:***
- go to http://test-nik.playground.kitchen.it.taocloud.org:48161/
- create an item and start adding a passage to the item
- check the preview window when selecting a passage

What is `getProcessedFileStream`:
https://github.com/oat-sa/extension-tao-mediamanager/blob/master/model/MediaSource.php#L325
https://github.com/oat-sa/extension-tao-mediamanager/blob/master/model/export/service/MediaResourcePreparer.php#L54