### PR TITLE
fix: allow user to move class when taoDacSimple is enabled. 

### DIFF
--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -126,7 +126,7 @@ class taoItems_actions_Items extends tao_actions_SaSModule
     /**
      * overwrite the parent moveAllInstances to add the requiresRight only in Items
      * @see tao_actions_TaoModule::moveResource()
-     * @requiresRight uri WRITE
+     * @requiresRight classUri WRITE
      */
     public function moveResource()
     {


### PR DESCRIPTION
When taoDacSimple is enabled user lose `move to` functionality on class level. 
In order to fix this issue I modify `@requiresRight` for `taoItems_actions_Items::moveResource`. 

https://oat-sa.atlassian.net/browse/AUT-198