### PR TITLE
Fix/ADF-480/Fix permissions to view buttons

### DIFF
--- a/actions/class.ItemImport.php
+++ b/actions/class.ItemImport.php
@@ -43,7 +43,7 @@ class taoItems_actions_ItemImport extends tao_actions_Import
      * overwrite the parent index to add the requiresRight for Items only
      *
      * @requiresRight id WRITE
-     * @see           tao_actions_Import::index()
+     * @requiresRight classUri WRITE
      */
     public function index()
     {
@@ -77,10 +77,10 @@ class taoItems_actions_ItemImport extends tao_actions_Import
                     $importer = new CsvItemImporter($this->getPsrRequest());
                     $importer->setServiceLocator($this->getServiceLocator());
                     $returnValue[$key] = $importer;
-                    
+
                     continue;
                 }
-                
+
                 unset($returnValue[$key]);
             }
         }

--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -84,24 +84,6 @@ class taoItems_actions_Items extends tao_actions_SaSModule
     }
 
     /**
-     * overwrite the parent addInstance to add the requiresRight only in Items
-     * @requiresRight id WRITE
-     */
-    public function addInstance()
-    {
-        parent::addInstance();
-    }
-
-    /**
-     * overwrite the parent addSubClass to add the requiresRight only in Items
-     * @requiresRight id WRITE
-     */
-    public function addSubClass()
-    {
-        parent::addSubClass();
-    }
-
-    /**
      * overwrite the parent cloneInstance to add the requiresRight only in Items
      * @see tao_actions_TaoModule::cloneInstance()
      * @requiresRight uri READ
@@ -121,16 +103,6 @@ class taoItems_actions_Items extends tao_actions_SaSModule
     public function moveInstance()
     {
         return parent::moveInstance();
-    }
-
-    /**
-     * overwrite the parent moveAllInstances to add the requiresRight only in Items
-     * @see tao_actions_TaoModule::moveResource()
-     * @requiresRight classUri WRITE
-     */
-    public function moveResource()
-    {
-        return parent::moveResource();
     }
 
     /**


### PR DESCRIPTION
**Relates to:** _[ADF-480](https://oat-sa.atlassian.net/browse/ADF-480)_

---

**How to test:**
1. Create new role `Test Takers Author` with included `Test Takers Manager` role;
2. Create a new user (e.g `Test User`) with the following list of roles:  
a. Item Author;
b. Test Author;
c. Test Takers Author (our new role);
3. Go to Items and create a new class;
4. Change Access Rights for this class:
a. Add `Global Manager` role and set `GRANT` access level to him;
b. Set `READ` access level to `Back Office` role;
5. Create a new item in this class;
6. Change Access Rights for this item: set `GRANT` access level to our new user (`Test User`);
7. Log in as Test User and select this item.

**Previous behavior:** _user can see `New class`, `Import`, `New item` buttons._
**Current behavior:** _user cannot see `New class`, `Import`, `New item` buttons._

```diff
! Repeat steps 3 - 7 for: Tests, Test-takers, Assets.
```
---

**Companion PRs:**
* https://github.com/oat-sa/tao-core/pull/3012
* https://github.com/oat-sa/extension-tao-mediamanager/pull/294
* https://github.com/oat-sa/extension-tao-itemqti/pull/1827
* https://github.com/oat-sa/extension-tao-test/pull/375
* https://github.com/oat-sa/extension-tao-testtaker/pull/190