### PR TITLE
Backport/adf 489/acl user cant delete mediafiles

### DIFF
--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -34,7 +34,7 @@ use oat\tao\model\resources\ResourceAccessDeniedException;
 use oat\taoItems\model\media\AssetTreeBuilder;
 use oat\taoItems\model\media\AssetTreeBuilderInterface;
 use oat\taoItems\model\media\ItemMediaResolver;
-use oat\taoMediaManager\model\MediaSource;
+use oat\taoItems\model\media\LocalItemSource;
 use Psr\Http\Message\StreamInterface;
 use common_exception_MissingParameter as MissingParameterException;
 use tao_models_classes_FileNotFoundException as FileNotFoundException;
@@ -205,10 +205,10 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
         $asset = $this->resolveAsset($params['uri'], $params['path'], $params['lang']);
 
         $mediaSource = $asset->getMediaSource();
-        if ($mediaSource instanceof MediaSource) {
-            $resourceUri = tao_helpers_Uri::decode($asset->getMediaIdentifier());
-        } else {
+        if ($mediaSource instanceof LocalItemSource) {
             $resourceUri = $params['uri'];
+        } else {
+            $resourceUri = tao_helpers_Uri::decode($asset->getMediaIdentifier());
         }
 
         if ($validateWriteAccess && !$this->getPermissionChecker()->hasWriteAccess($resourceUri)) {

--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -34,8 +34,8 @@ use oat\tao\model\resources\ResourceAccessDeniedException;
 use oat\taoItems\model\media\AssetTreeBuilder;
 use oat\taoItems\model\media\AssetTreeBuilderInterface;
 use oat\taoItems\model\media\ItemMediaResolver;
-use Psr\Http\Message\StreamInterface;
 use oat\taoMediaManager\model\MediaSource;
+use Psr\Http\Message\StreamInterface;
 use common_exception_MissingParameter as MissingParameterException;
 use tao_models_classes_FileNotFoundException as FileNotFoundException;
 

--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -202,7 +202,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
     {
         $params = $this->getRequiredQueryParams('uri', 'lang', 'path');
         $asset = $this->resolveAsset($params['uri'], $params['path'], $params['lang']);
-        $resourceUri = tao_helpers_Uri::decode($asset->getMediaIdentifier());
+        $resourceUri = $params['uri'];
 
         if ($validateWriteAccess && !$this->getPermissionChecker()->hasWriteAccess($resourceUri)) {
             throw new ResourceAccessDeniedException($resourceUri);

--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -204,12 +204,9 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
         $params = $this->getRequiredQueryParams('uri', 'lang', 'path');
         $asset = $this->resolveAsset($params['uri'], $params['path'], $params['lang']);
 
-        $mediaSource = $asset->getMediaSource();
-        if ($mediaSource instanceof LocalItemSource) {
-            $resourceUri = $params['uri'];
-        } else {
-            $resourceUri = tao_helpers_Uri::decode($asset->getMediaIdentifier());
-        }
+        $resourceUri = $asset->getMediaSource() instanceof LocalItemSource
+            ? $params['uri']
+            : tao_helpers_Uri::decode($asset->getMediaIdentifier());
 
         if ($validateWriteAccess && !$this->getPermissionChecker()->hasWriteAccess($resourceUri)) {
             throw new ResourceAccessDeniedException($resourceUri);

--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -35,6 +35,7 @@ use oat\taoItems\model\media\AssetTreeBuilder;
 use oat\taoItems\model\media\AssetTreeBuilderInterface;
 use oat\taoItems\model\media\ItemMediaResolver;
 use Psr\Http\Message\StreamInterface;
+use oat\taoMediaManager\model\MediaSource;
 use common_exception_MissingParameter as MissingParameterException;
 use tao_models_classes_FileNotFoundException as FileNotFoundException;
 
@@ -202,7 +203,13 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
     {
         $params = $this->getRequiredQueryParams('uri', 'lang', 'path');
         $asset = $this->resolveAsset($params['uri'], $params['path'], $params['lang']);
-        $resourceUri = $params['uri'];
+
+        $mediaSource = $asset->getMediaSource();
+        if ($mediaSource instanceof MediaSource) {
+            $resourceUri = tao_helpers_Uri::decode($asset->getMediaIdentifier());
+        } else {
+            $resourceUri = $params['uri'];
+        }
 
         if ($validateWriteAccess && !$this->getPermissionChecker()->hasWriteAccess($resourceUri)) {
             throw new ResourceAccessDeniedException($resourceUri);


### PR DESCRIPTION
Backporting: https://oat-sa.atlassian.net/browse/ADF-489

[release-2021-08-lts 710e1094] fix: ACL user can't delete media files
 Author: Chinnu Francis <chinnu@focaloid.com>
 Date: Mon Jul 12 16:34:16 2021 +0530
 1 file changed, 1 insertion(+), 1 deletion(-)
[release-2021-08-lts fb953471] chore: Handle assets files and Item files
 Author: Chinnu Francis <chinnu@focaloid.com>
 Date: Tue Jul 13 12:49:56 2021 +0530
 1 file changed, 8 insertions(+), 1 deletion(-)
[release-2021-08-lts ed26f88f] chore: Minor change
 Author: Chinnu Francis <chinnu@focaloid.com>
 Date: Tue Jul 13 12:52:24 2021 +0530
 1 file changed, 1 insertion(+), 1 deletion(-)
[release-2021-08-lts 3370dce9] chore: check media source
 Author: Chinnu Francis <chinnu@focaloid.com>
 Date: Tue Jul 13 17:05:12 2021 +0530
 1 file changed, 4 insertions(+), 4 deletions(-)
[release-2021-08-lts 1a345658] chore: removing if else
 Author: Chinnu Francis <chinnu@focaloid.com>
 Date: Tue Jul 13 17:14:02 2021 +0530
 1 file changed, 3 insertions(+), 6 deletions(-)