### PR TITLE
Feature/aut 899/e2e test items page create add properties assign values

### DIFF
--- a/views/cypress/tests/item.spec.js
+++ b/views/cypress/tests/item.spec.js
@@ -23,7 +23,7 @@ import selectors from '../utils/selectors';
 describe('Items', () => {
     const className = 'Test E2E class';
     const newPropertyName = 'I am a new property in testing, hi!';
-    const itemName = 'Test E2E item 1'
+    const itemName = 'Test E2E item 1';
 
     /**
      * Visit the page
@@ -59,14 +59,14 @@ describe('Items', () => {
         it('can create and rename a new item', function () {
             cy.selectNode(selectors.root, selectors.itemClassForm, className);
             cy.addNode(selectors.itemForm, selectors.addItem);
-            cy.renameSelected(selectors.itemForm, 'Test E2E item 1');
+            cy.renameSelected(selectors.itemForm, itemName);
         });
 
         it('can give a property value to an item', function () {
             cy.selectNode(selectors.root, selectors.itemClassForm, className);
             cy.addNode(selectors.itemForm, selectors.addItem);
             cy.assignValueToProperty(itemName, selectors.itemForm, selectors.selectTrue);
-        })
+        });
 
         it('can delete item', function () {
             cy.selectNode(selectors.root, selectors.itemClassForm, className);

--- a/views/cypress/tests/item.spec.js
+++ b/views/cypress/tests/item.spec.js
@@ -22,6 +22,7 @@ import selectors from '../utils/selectors';
 
 describe('Items', () => {
     const className = 'Test E2E class';
+    const newPropertyName = 'I am a new property in testing, hi!';
 
     /**
      * Visit the page
@@ -43,6 +44,15 @@ describe('Items', () => {
     describe('Item creation, editing and deletion', () => {
         it('can create a new item class', function () {
             cy.addClassToRoot(selectors.root, selectors.itemClassForm, className);
+        });
+        it('can create and edit a new property for the class', function () {
+            cy.addPropertyToClass(
+                selectors.newClass,
+                selectors.editClass,
+                selectors.classOptions,
+                newPropertyName,
+                selectors.propertyEdit
+            );
         });
 
         it('can create and rename a new item', function () {
@@ -67,5 +77,6 @@ describe('Items', () => {
                 className
             );
         });
+
     });
 });

--- a/views/cypress/tests/item.spec.js
+++ b/views/cypress/tests/item.spec.js
@@ -23,6 +23,7 @@ import selectors from '../utils/selectors';
 describe('Items', () => {
     const className = 'Test E2E class';
     const newPropertyName = 'I am a new property in testing, hi!';
+    const itemName = 'Test E2E item 1'
 
     /**
      * Visit the page
@@ -45,9 +46,9 @@ describe('Items', () => {
         it('can create a new item class', function () {
             cy.addClassToRoot(selectors.root, selectors.itemClassForm, className);
         });
-        it('can create and edit a new property for the class', function () {
+        it('can edit and add new property for the class', function () {
             cy.addPropertyToClass(
-                selectors.newClass,
+                className,
                 selectors.editClass,
                 selectors.classOptions,
                 newPropertyName,
@@ -60,6 +61,12 @@ describe('Items', () => {
             cy.addNode(selectors.itemForm, selectors.addItem);
             cy.renameSelected(selectors.itemForm, 'Test E2E item 1');
         });
+
+        it('can give a property value to an item', function () {
+            cy.selectNode(selectors.root, selectors.itemClassForm, className);
+            cy.addNode(selectors.itemForm, selectors.addItem);
+            cy.assignValueToProperty(itemName, selectors.itemForm, selectors.selectTrue);
+        })
 
         it('can delete item', function () {
             cy.selectNode(selectors.root, selectors.itemClassForm, className);

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -10,5 +10,6 @@ export default {
     classForm: 'form[data-action= "/taoItems/Items/editItemClass"]',
     propertyEdit: 'div[class="form-group property-block regular-property property-edit-container-open"]',
     deleteConfirm: '[data-control="delete"]',
+    selectTrue: 'input[type="radio"][value="http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_True"]',
     root: '[data-uri="http://www.tao.lu/Ontologies/TAOItem.rdf#Item"]'
 };

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -6,7 +6,7 @@ export default {
     itemForm: 'form[action="/taoItems/Items/editItem"]',
     itemClassForm: 'form[action="/taoItems/Items/editClassLabel"]',
     classOptions: '[action="/taoItems/Items/editItemClass"]',
-    editClass: 'ul[class="plain action-bar content-action-bar horizontal-action-bar"]',
+    editClass: '#item-class-schema',
     classForm: 'form[data-action= "/taoItems/Items/editItemClass"]',
     propertyEdit: 'div[class="form-group property-block regular-property property-edit-container-open"]',
     deleteConfirm: '[data-control="delete"]',

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -1,9 +1,14 @@
 export default {
     deleteItem: '[data-context="instance"][data-action="deleteItem"]',
     deleteClass: '[data-context="class"][data-action="deleteItemClass"]',
+    newClass: '[data-context="resource"][data-action="subClass"]',
     addItem: '[data-context="resource"][data-action="instanciate"]',
     itemForm: 'form[action="/taoItems/Items/editItem"]',
     itemClassForm: 'form[action="/taoItems/Items/editClassLabel"]',
+    classOptions: '[action="/taoItems/Items/editItemClass"]',
+    editClass: 'ul[class="plain action-bar content-action-bar horizontal-action-bar"]',
+    classForm: 'form[data-action= "/taoItems/Items/editItemClass"]',
+    propertyEdit: 'div[class="form-group property-block regular-property property-edit-container-open"]',
     deleteConfirm: '[data-control="delete"]',
     root: '[data-uri="http://www.tao.lu/Ontologies/TAOItem.rdf#Item"]'
 };


### PR DESCRIPTION
End to end testing.
Related to: https://oat-sa.atlassian.net/browse/AUT-899
Related to (original): oat-sa/tao-core#2814

**Description of changes:**
Creation of E2E tests  added using cypress.
Tests for property creation in class and item property and value assignation.

How to run locally:
Checkou to feature/aut 899/e2e test items page create add properties assign values, in tao core
Checkou to feature/aut 899/e2e test items page create add properties assign values, in taoItem

run tests from tao core extn: 
 npm run cy:open - to run in browser
or npm run cy:run - for headless execution