### PR TITLE
Backport/ADF-573/atomic roles improvements

### DIFF
--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -202,7 +202,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
 
     private function getMediaAsset(string $action): ?MediaAsset
     {
-        $isWrite = in_array($action, ['deleteAsset', 'uploadAsset']);
+        $isWrite = in_array($action, ['deleteAsset', 'uploadAsset'], true);
         $params = $this->getRequiredQueryParams('uri', 'lang');
         $queryParams = $this->getPsrRequest()->getQueryParams();
         $path = $queryParams['relPath'] ?? $queryParams['path'] ?? null;

--- a/actions/class.ItemImport.php
+++ b/actions/class.ItemImport.php
@@ -37,7 +37,8 @@ use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
  */
 class taoItems_actions_ItemImport extends tao_actions_Import
 {
-    public const FEATURE_FLAG_TABULAR_IMPORT = 'FEATURE_FLAG_TABULAR_IMPORT_ENABLED';
+    /** @deprecated Use oat\tao\model\featureFlag\FeatureFlagCheckerInterface::FEATURE_FLAG_TABULAR_IMPORT */
+    public const FEATURE_FLAG_TABULAR_IMPORT = FeatureFlagCheckerInterface::FEATURE_FLAG_TABULAR_IMPORT;
 
     /**
      * overwrite the parent index to add the requiresRight for Items only
@@ -73,7 +74,7 @@ class taoItems_actions_ItemImport extends tao_actions_Import
 
         foreach (array_keys($returnValue) as $key) {
             if ($returnValue[$key] instanceof \tao_models_classes_import_CsvImporter) {
-                if ($this->getFeatureFlagChecker()->isEnabled(self::FEATURE_FLAG_TABULAR_IMPORT)) {
+                if ($this->getFeatureFlagChecker()->isEnabled(FeatureFlagCheckerInterface::FEATURE_FLAG_TABULAR_IMPORT)) {
                     $importer = new CsvItemImporter($this->getPsrRequest());
                     $importer->setServiceLocator($this->getServiceLocator());
                     $returnValue[$key] = $importer;

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=14.0.0",
-        "oat-sa/tao-core": ">=48.19.2",
+        "oat-sa/tao-core": ">=48.23.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/manifest.php
+++ b/manifest.php
@@ -175,7 +175,22 @@ return [
             AccessRule::GRANT,
             TaoItemsRoles::ITEM_CONTENT_CREATOR,
             ['ext' => 'taoItems', 'mod' => 'Items', 'act' => 'authoring'],
-        ]
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_CONTENT_CREATOR,
+            ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'delete'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_CONTENT_CREATOR,
+            ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'fileExists'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_CONTENT_CREATOR,
+            ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'upload'],
+        ],
     ],
     'optimizableClasses' => [
         'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',

--- a/manifest.php
+++ b/manifest.php
@@ -191,6 +191,21 @@ return [
             TaoItemsRoles::ITEM_CONTENT_CREATOR,
             ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'upload'],
         ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_IMPORTER,
+            ['ext' => 'taoItems', 'mod' => 'ItemImport', 'act' => 'index'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_DELETER,
+            ['ext' => 'taoItems', 'mod' => 'Items', 'act' => 'deleteItem'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_DELETER,
+            ['ext' => 'taoItems', 'mod' => 'Items', 'act' => 'moveInstance'],
+        ],
     ],
     'optimizableClasses' => [
         'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',

--- a/migrations/Version202108030710512141_taoItems.php
+++ b/migrations/Version202108030710512141_taoItems.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\taoItems\model\user\TaoItemsRoles;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\tools\accessControl\SetRolesAccess;
+
+final class Version202108030710512141_taoItems extends AbstractMigration
+{
+    private const CONFIG = [
+        SetRolesAccess::CONFIG_RULES => [
+            TaoItemsRoles::ITEM_IMPORTER => [
+                ['ext' => 'taoItems', 'mod' => 'ItemImport', 'act' => 'index'],
+            ],
+            TaoItemsRoles::ITEM_DELETER => [
+                ['ext' => 'taoItems', 'mod' => 'Items', 'act' => 'deleteItem'],
+                ['ext' => 'taoItems', 'mod' => 'Items', 'act' => 'moveInstance'],
+            ],
+            TaoItemsRoles::ITEM_CONTENT_CREATOR => [
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'fileExists'],
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'upload'],
+            ],
+        ],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Configure permissions for Item Importer, Deleter and content creator role';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess(
+            [
+                '--' . SetRolesAccess::OPTION_CONFIG,
+                self::CONFIG,
+            ]
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_REVOKE,
+            '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+        ]);
+    }
+}

--- a/migrations/Version202108100944252141_taoItems.php
+++ b/migrations/Version202108100944252141_taoItems.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoItems\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\taoItems\model\user\TaoItemsRoles;
+use oat\tao\scripts\tools\accessControl\SetRolesAccess;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+final class Version202108100944252141_taoItems extends AbstractMigration
+{
+    private const CONFIG = [
+        SetRolesAccess::CONFIG_RULES => [
+            TaoItemsRoles::ITEM_CONTENT_CREATOR => [
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'delete'],
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'fileExists'],
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'upload'],
+            ],
+        ],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Item content creator role to author existing item';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess(
+            [
+                '--' . SetRolesAccess::OPTION_CONFIG,
+                self::CONFIG,
+            ]
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_REVOKE,
+            '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+        ]);
+    }
+}

--- a/migrations/Version202108100944252141_taoItems.php
+++ b/migrations/Version202108100944252141_taoItems.php
@@ -15,8 +15,6 @@ final class Version202108100944252141_taoItems extends AbstractMigration
         SetRolesAccess::CONFIG_RULES => [
             TaoItemsRoles::ITEM_CONTENT_CREATOR => [
                 ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'delete'],
-                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'fileExists'],
-                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'upload'],
             ],
         ],
     ];

--- a/models/classes/user/TaoItemsRoles.php
+++ b/models/classes/user/TaoItemsRoles.php
@@ -38,4 +38,7 @@ interface TaoItemsRoles
     public const ITEM_PREVIEWER = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemPreviewerRole';
     public const ITEM_PROPERTIES_EDITOR = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemPropertiesEditorRole';
     public const ITEM_CONTENT_CREATOR = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemContentCreatorRole';
+    public const ITEM_RESOURCE_CREATOR = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemResourceCreatorRole';
+    public const ITEM_IMPORTER = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemImporterRole';
+    public const ITEM_DELETER = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemDeleterRole';
 }

--- a/models/ontology/taoitem.rdf
+++ b/models/ontology/taoitem.rdf
@@ -187,4 +187,22 @@
     <rdfs:comment xml:lang="en-US"><![CDATA[Item Content Creator Role]]></rdfs:comment>
     <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemPreviewerRole"/>
   </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemResourceCreatorRole">
+    <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemRole"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Item Resource Creator]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Item Resource Creator Role]]></rdfs:comment>
+    <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemPropertiesEditorRole"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemImporterRole">
+    <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemRole"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Item Importer]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Item Importer Role]]></rdfs:comment>
+    <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemResourceCreatorRole"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemDeleterRole">
+    <rdf:type rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemRole"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Item Deleter]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Item Deleter Role]]></rdfs:comment>
+    <generis:includesRole rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemPreviewerRole"/>
+  </rdf:Description>
 </rdf:RDF>

--- a/views/cypress/tests/item.spec.js
+++ b/views/cypress/tests/item.spec.js
@@ -19,43 +19,100 @@
 import urls from '../utils/urls';
 import selectors from '../utils/selectors';
 
-
 describe('Items', () => {
     const className = 'Test E2E class';
+    const classMovedName = 'Test E2E class Moved';
+    const newPropertyName = 'I am a new property in testing, hi!';
+    const itemName = 'Test E2E item 1';
 
     /**
-     * Visit the page
-     */
-    beforeEach(() => {
-        cy.visit(urls.items);
-    });
-
-    /**
-     * Log in
+     * Log in and wait for render
+     * After @treeRender click root class
      */
     before(() => {
         cy.loginAsAdmin();
+        cy.intercept('GET', `**/${ selectors.treeRenderUrl }/getOntologyData**`).as('treeRender');
+        cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel');
+        cy.visit(urls.items);
+        cy.wait('@treeRender', { requestTimeout: 10000 });
+        cy.get(`${selectors.root} a`)
+            .first()
+            .click();
+        cy.wait('@editClassLabel', { requestTimeout: 10000 });
     });
 
     /**
      * Tests
      */
-    describe('Item creation, editing and deletion', () => {
+    describe('Item Class creation and editing', () => {
         it('can create a new item class', function () {
-            cy.addClassToRoot(selectors.root, selectors.itemClassForm, className);
+            cy.addClassToRoot(
+                selectors.root,
+                selectors.itemClassForm,
+                className,
+                selectors.editClassLabelUrl,
+                selectors.treeRenderUrl,
+                selectors.addSubClassUrl
+            );
         });
 
+        it('can edit and add new property for the class', function () {
+            cy.addPropertyToClass(
+                className,
+                selectors.editClass,
+                selectors.classOptions,
+                newPropertyName,
+                selectors.propertyEdit,
+                selectors.editClassUrl
+            );
+        });
+    });
+
+    describe('Item creation and edition', () => {
         it('can create and rename a new item', function () {
-            cy.selectNode(selectors.root, selectors.itemClassForm, className);
-            cy.addNode(selectors.itemForm, selectors.addItem);
-            cy.renameSelected(selectors.itemForm, 'Test E2E item 1');
+            cy.selectNode(selectors.root, selectors.itemClassForm, className)
+                .addNode(selectors.itemForm, selectors.addItem)
+                .renameSelectedItem(selectors.itemForm, selectors.editItemUrl, 'Test E2E item 1');
         });
 
-        it('can delete item', function () {
+        it('can give a property value to an item', function () {
             cy.selectNode(selectors.root, selectors.itemClassForm, className);
-            cy.addNode(selectors.itemForm, selectors.addItem);
-            cy.renameSelected(selectors.itemForm, 'Test E2E item 2');
-            cy.deleteNode(selectors.deleteItem, 'Test E2E item 2');
+            cy.assignValueToProperty(itemName, selectors.itemForm, selectors.selectTrue, selectors.treeRenderUrl);
+        });
+    });
+
+    describe('Moving and deleting', () => {
+        it('can delete item', function () {
+            cy.selectNode(selectors.root, selectors.itemClassForm, className)
+                .addNode(selectors.itemForm, selectors.addItem)
+                .renameSelectedItem(selectors.itemForm, selectors.editItemUrl, 'Test E2E item 2')
+                .deleteNode(
+                    selectors.root,
+                    selectors.deleteItem,
+                    selectors.editItemUrl,
+                    'Test E2E item 2',
+                );
+        });
+
+        it('can move item class', function () {
+            cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel');
+
+            cy.getSettled(`${selectors.root} a:nth(0)`)
+            .click()
+            .wait('@editClassLabel', { requestTimeout: 10000 })
+            .addClass(selectors.itemClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
+            .renameSelectedClass(selectors.itemClassForm, classMovedName);
+
+            cy.wait('@treeRender', { requestTimeout: 10000 });
+
+            cy.moveClassFromRoot(
+                selectors.root,
+                selectors.moveClass,
+                selectors.moveConfirmSelector,
+                className,
+                classMovedName,
+                selectors.restResourceGetAll
+            );
         });
 
         it('can delete item class', function () {
@@ -64,7 +121,32 @@ describe('Items', () => {
                 selectors.itemClassForm,
                 selectors.deleteClass,
                 selectors.deleteConfirm,
-                className
+                classMovedName,
+                selectors.deleteClassUrl,
+                true
+            );
+        });
+
+        it('can delete empty item class', function () {
+            cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel')
+            cy.getSettled(`${selectors.root} a:nth(0)`)
+            .click()
+            .wait('@editClassLabel', { requestTimeout: 10000 })
+            .addClass(selectors.itemClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
+            .renameSelectedClass(selectors.itemClassForm, className);
+
+            cy.wait('@editClassLabel', { requestTimeout: 10000 });
+
+            cy.deleteClassFromRoot(
+                selectors.root,
+                selectors.itemClassForm,
+                selectors.deleteClass,
+                selectors.deleteConfirm,
+                className,
+                selectors.deleteClassUrl,
+                selectors.resourceRelations,
+                false,
+                true
             );
         });
     });

--- a/views/cypress/utils/selectors.js
+++ b/views/cypress/utils/selectors.js
@@ -1,9 +1,21 @@
 export default {
     deleteItem: '[data-context="instance"][data-action="deleteItem"]',
     deleteClass: '[data-context="class"][data-action="deleteItemClass"]',
+    moveClass: '[id="item-move-to"][data-context="resource"][data-action="moveTo"]',
+    moveConfirmSelector: 'button[data-control="ok"]',
+    newClass: '[data-context="resource"][data-action="subClass"]',
     addItem: '[data-context="resource"][data-action="instanciate"]',
     itemForm: 'form[action="/taoItems/Items/editItem"]',
     itemClassForm: 'form[action="/taoItems/Items/editClassLabel"]',
     deleteConfirm: '[data-control="delete"]',
-    root: '[data-uri="http://www.tao.lu/Ontologies/TAOItem.rdf#Item"]'
+    root: '[data-uri="http://www.tao.lu/Ontologies/TAOItem.rdf#Item"]',
+    editClassLabelUrl: 'taoItems/Items/editClassLabel',
+    editItemUrl: 'taoItems/Items/editItem',
+    treeRenderUrl: 'taoItems/Items',
+    addSubClassUrl: 'taoItems/Items/addSubClass',
+    editClassUrl: 'taoItems/Items/editItemClass',
+    deleteClassUrl: 'taoItems/Items/deleteClass',
+    restResourceGetAll: 'tao/RestResource/getAll',
+    resourceRelations: 'tao/ResourceRelations',
+    selectTrue: 'input[type="radio"][value="http_2_www_0_tao_0_lu_1_Ontologies_1_generis_0_rdf_3_True"]'
 };


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-573

commit efb960a2e491436aa18064a8706a89d8e98e5531
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Thu Aug 12 16:35:34 2021 +0200

    chore: remove duplicated permissios

commit b64af90620dcb0efa795a43ad1199e33ec142b76
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Thu Aug 12 16:31:40 2021 +0200

    chore: use strict in_array

commit e5cb09a5d11868cabc79e042eb45030bc22e2a7b
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Thu Aug 12 16:23:01 2021 +0200

    Merge branch 'develop' of https://github.com/oat-sa/extension-tao-item into feature/ADF-573/atomic-roles-improvements

commit 6665d2c2d380452b407899b9ec855cec7e9f9cc6
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Thu Aug 12 13:43:11 2021 +0200

    chore: merge develop

commit 8826507bac5d2d193eba9e3df5304590602fca4c
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Wed Aug 11 10:02:54 2021 +0200

    feat: installation roles for ACL

commit f4576243b6a0c1013c34da192b0a55f8b53858c9
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Tue Aug 10 17:07:06 2021 +0200

    feat: add item and assets permissions validation