### PR TITLE
Backport/ADF-573/atomic roles improvements

### DIFF
--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -202,7 +202,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
 
     private function getMediaAsset(string $action): ?MediaAsset
     {
-        $isWrite = in_array($action, ['deleteAsset', 'uploadAsset']);
+        $isWrite = in_array($action, ['deleteAsset', 'uploadAsset'], true);
         $params = $this->getRequiredQueryParams('uri', 'lang');
         $queryParams = $this->getPsrRequest()->getQueryParams();
         $path = $queryParams['relPath'] ?? $queryParams['path'] ?? null;

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=14.0.0",
-        "oat-sa/tao-core": ">=48.19.2",
+        "oat-sa/tao-core": ">=48.20.2",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/manifest.php
+++ b/manifest.php
@@ -175,7 +175,22 @@ return [
             AccessRule::GRANT,
             TaoItemsRoles::ITEM_CONTENT_CREATOR,
             ['ext' => 'taoItems', 'mod' => 'Items', 'act' => 'authoring'],
-        ]
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_CONTENT_CREATOR,
+            ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'delete'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_CONTENT_CREATOR,
+            ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'fileExists'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_CONTENT_CREATOR,
+            ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'upload'],
+        ],
     ],
     'optimizableClasses' => [
         'http://www.tao.lu/Ontologies/TAOItem.rdf#Item',

--- a/migrations/Version202108100944252141_taoItems.php
+++ b/migrations/Version202108100944252141_taoItems.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoItems\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\taoItems\model\user\TaoItemsRoles;
+use oat\tao\scripts\tools\accessControl\SetRolesAccess;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+
+final class Version202108100944252141_taoItems extends AbstractMigration
+{
+    private const CONFIG = [
+        SetRolesAccess::CONFIG_RULES => [
+            TaoItemsRoles::ITEM_CONTENT_CREATOR => [
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'delete'],
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'fileExists'],
+                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'upload'],
+            ],
+        ],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'Item content creator role to author existing item';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess(
+            [
+                '--' . SetRolesAccess::OPTION_CONFIG,
+                self::CONFIG,
+            ]
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_REVOKE,
+            '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+        ]);
+    }
+}

--- a/migrations/Version202108100944252141_taoItems.php
+++ b/migrations/Version202108100944252141_taoItems.php
@@ -15,8 +15,6 @@ final class Version202108100944252141_taoItems extends AbstractMigration
         SetRolesAccess::CONFIG_RULES => [
             TaoItemsRoles::ITEM_CONTENT_CREATOR => [
                 ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'delete'],
-                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'fileExists'],
-                ['ext' => 'taoItems', 'mod' => 'ItemContent', 'act' => 'upload'],
             ],
         ],
     ];


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-573

commit 1a9e972d18fd8088c767d97bc714d2f046c0e349
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Thu Aug 12 16:35:34 2021 +0200

    chore: remove duplicated permissios

commit b5f01d6f5fe50a65d9e6c53b7b520853fdbce8c4
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Thu Aug 12 16:31:40 2021 +0200

    chore: use strict in_array

commit 07a56b4badd7c9b6954d88e827cb3eb46e95b15a
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Wed Aug 11 10:02:54 2021 +0200

    feat: installation roles for ACL

commit f2bb0d74ead6e3109ea05cd89db504bffa4a168d
Author: Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
Date:   Tue Aug 10 17:07:06 2021 +0200

    feat: add item and assets permissions validation