### PR TITLE
Item Content Creator Role (alone) cannot list/insert/delete/preview/download assets

### DIFF
--- a/migrations/Version202108250549242141_taoItems.php
+++ b/migrations/Version202108250549242141_taoItems.php
@@ -17,15 +17,6 @@ final class Version202108250549242141_taoItems extends AbstractMigration
     private const CONFIG = [
         SetRolesAccess::CONFIG_PERMISSIONS => [
             taoItems_actions_ItemContent::class => [
-                'upload' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
-                ],
-                'download' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
-                ],
-                'delete' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
-                ],
                 'previewAsset' => [
                     TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
                 ],
@@ -44,7 +35,7 @@ final class Version202108250549242141_taoItems extends AbstractMigration
 
     public function getDescription(): string
     {
-        return 'Configure insert/delete/download asset permissions for Item Content creator role';
+        return 'Configure insert/preview/delete/download asset permissions for Item Content creator role';
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version202108250549242141_taoItems.php
+++ b/migrations/Version202108250549242141_taoItems.php
@@ -26,13 +26,25 @@ final class Version202108250549242141_taoItems extends AbstractMigration
                 'delete' => [
                     TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
                 ],
+                'previewAsset' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'downloadAsset' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'uploadAsset' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'deleteAsset' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
             ],
         ],
     ];
 
     public function getDescription(): string
     {
-        return 'configure deny for insert/delete/download actions for Item Content creator role';
+        return 'Configure insert/delete/download asset permissions for Item Content creator role';
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version202108250549242141_taoItems.php
+++ b/migrations/Version202108250549242141_taoItems.php
@@ -1,33 +1,54 @@
 <?php
 
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ */
+
 declare(strict_types=1);
 
 namespace oat\taoItems\migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use oat\tao\scripts\tools\migrations\AbstractMigration;
-use oat\tao\scripts\tools\accessControl\SetRolesAccess;
-use oat\taoItems\model\user\TaoItemsRoles;
-use oat\tao\model\accessControl\ActionAccessControl;
-use oat\tao\scripts\update\OntologyUpdater;
 use taoItems_actions_ItemContent;
+use oat\taoItems\model\user\TaoItemsRoles;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\tao\model\accessControl\ActionAccessControl;
+use oat\tao\scripts\tools\accessControl\SetRolesAccess;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
 
 final class Version202108250549242141_taoItems extends AbstractMigration
 {
     private const CONFIG = [
         SetRolesAccess::CONFIG_PERMISSIONS => [
             taoItems_actions_ItemContent::class => [
+                'viewAsset' => [
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                ],
                 'previewAsset' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                 ],
                 'downloadAsset' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                 ],
                 'uploadAsset' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                 ],
                 'deleteAsset' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                 ],
             ],
         ],
@@ -51,7 +72,7 @@ final class Version202108250549242141_taoItems extends AbstractMigration
 
     public function getDescription(): string
     {
-        return 'Configure insert/preview/delete/download asset permissions for Item Content creator role. Also remove unnecessary permissions of Item Class navigator Role';
+        return 'Configure asset permissions for Item Content creator role.';
     }
 
     public function up(Schema $schema): void

--- a/migrations/Version202108250549242141_taoItems.php
+++ b/migrations/Version202108250549242141_taoItems.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoItems\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\tools\accessControl\SetRolesAccess;
+use oat\taoItems\model\user\TaoItemsRoles;
+use oat\tao\model\accessControl\ActionAccessControl;
+use oat\tao\scripts\update\OntologyUpdater;
+use taoItems_actions_ItemContent;
+
+final class Version202108250549242141_taoItems extends AbstractMigration
+{
+    private const CONFIG = [
+        SetRolesAccess::CONFIG_PERMISSIONS => [
+            taoItems_actions_ItemContent::class => [
+                'upload' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'download' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'delete' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+            ],
+        ],
+    ];
+
+    public function getDescription(): string
+    {
+        return 'configure deny for insert/delete/download actions for Item Content creator role';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+        ]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_REVOKE,
+            '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+        ]);
+    }
+}

--- a/migrations/Version202108250549242141_taoItems.php
+++ b/migrations/Version202108250549242141_taoItems.php
@@ -33,15 +33,36 @@ final class Version202108250549242141_taoItems extends AbstractMigration
         ],
     ];
 
+    private const REVOKE_CONFIG = [
+        SetRolesAccess::CONFIG_PERMISSIONS => [
+            taoItems_actions_ItemContent::class => [
+                'files' => [
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                ],
+                'delete' => [
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                ],
+                'upload' => [
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                ],
+            ],
+        ],
+    ];
+
     public function getDescription(): string
     {
-        return 'Configure insert/preview/delete/download asset permissions for Item Content creator role';
+        return 'Configure insert/preview/delete/download asset permissions for Item Content creator role. Also remove unnecessary permissions of Item Class navigator Role';
     }
 
     public function up(Schema $schema): void
     {
         OntologyUpdater::syncModels();
 
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_REVOKE,
+            '--' . SetRolesAccess::OPTION_CONFIG, self::REVOKE_CONFIG,
+        ]);
         $setRolesAccess = $this->propagate(new SetRolesAccess());
         $setRolesAccess([
             '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
@@ -54,6 +75,10 @@ final class Version202108250549242141_taoItems extends AbstractMigration
         $setRolesAccess([
             '--' . SetRolesAccess::OPTION_REVOKE,
             '--' . SetRolesAccess::OPTION_CONFIG, self::CONFIG,
+        ]);
+        $setRolesAccess = $this->propagate(new SetRolesAccess());
+        $setRolesAccess([
+            '--' . SetRolesAccess::OPTION_CONFIG, self::REVOKE_CONFIG,
         ]);
     }
 }

--- a/scripts/install/SetRolesPermissions.php
+++ b/scripts/install/SetRolesPermissions.php
@@ -58,6 +58,18 @@ class SetRolesPermissions extends InstallAction
                 'download' => [
                     TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
                 ],
+                'previewAsset' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'downloadAsset' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'uploadAsset' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'deleteAsset' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
             ],
         ],
     ];

--- a/scripts/install/SetRolesPermissions.php
+++ b/scripts/install/SetRolesPermissions.php
@@ -44,17 +44,20 @@ class SetRolesPermissions extends InstallAction
                 ],
             ],
             taoItems_actions_ItemContent::class => [
+                'viewAsset' => [
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                ],
                 'previewAsset' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                 ],
                 'downloadAsset' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                 ],
                 'uploadAsset' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                 ],
                 'deleteAsset' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
                 ],
             ],
         ],

--- a/scripts/install/SetRolesPermissions.php
+++ b/scripts/install/SetRolesPermissions.php
@@ -49,14 +49,9 @@ class SetRolesPermissions extends InstallAction
                 ],
                 'delete' => [
                     TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
                 ],
                 'upload' => [
                     TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
-                ],
-                'download' => [
-                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
                 ],
                 'previewAsset' => [
                     TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,

--- a/scripts/install/SetRolesPermissions.php
+++ b/scripts/install/SetRolesPermissions.php
@@ -49,9 +49,14 @@ class SetRolesPermissions extends InstallAction
                 ],
                 'delete' => [
                     TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
                 ],
                 'upload' => [
                     TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
+                ],
+                'download' => [
+                    TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
                 ],
             ],
         ],

--- a/scripts/install/SetRolesPermissions.php
+++ b/scripts/install/SetRolesPermissions.php
@@ -44,15 +44,6 @@ class SetRolesPermissions extends InstallAction
                 ],
             ],
             taoItems_actions_ItemContent::class => [
-                'files' => [
-                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
-                ],
-                'delete' => [
-                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
-                ],
-                'upload' => [
-                    TaoItemsRoles::ITEM_CLASS_NAVIGATOR => ActionAccessControl::DENY,
-                ],
                 'previewAsset' => [
                     TaoItemsRoles::ITEM_CONTENT_CREATOR => ActionAccessControl::DENY,
                 ],


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/ADF-627
Description:
Item Content Creator Role (alone) cannot list/insert/delete/preview/download assets.
Also remove unnecessary permissions of Item Class navigator Role

---

**Companion PRs:**
* https://github.com/oat-sa/extension-tao-mediamanager/pull/312
* https://github.com/oat-sa/tao-core/pull/3085