### PR TITLE
fix: double move-to when dacSimple disabled

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -60,7 +60,7 @@
                     <action id="item-copy-to" name="Copy To" url="/taoItems/Items/copyInstance" context="instance" group="tree" binding="copyTo">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="item-move-to" name="Move To" url="/taoItems/Items/moveResource" context="resource" group="tree" binding="moveTo">
+                    <action id="item-move-to" name="Move To" url="/taoItems/Items/moveResource" context="instance" group="tree" binding="moveTo">
                         <icon id="icon-move-item"/>
                     </action>
                     <action id="class-move-to" name="Move To" url="/taoItems/Items/moveClass" context="class" group="tree" binding="moveTo">


### PR DESCRIPTION
When taoDacSimple is enabled move to button displays doubled. 

https://oat-sa.atlassian.net/browse/AUT-1008