### PR TITLE
AUT-1034 move requestTimeout to cypress.json configs

### DIFF
--- a/views/cypress/tests/item.spec.js
+++ b/views/cypress/tests/item.spec.js
@@ -34,11 +34,11 @@ describe('Items', () => {
         cy.intercept('GET', `**/${ selectors.treeRenderUrl }/getOntologyData**`).as('treeRender');
         cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel');
         cy.visit(urls.items);
-        cy.wait('@treeRender', { requestTimeout: 10000 });
+        cy.wait('@treeRender');
         cy.get(`${selectors.root} a`)
             .first()
             .click();
-        cy.wait('@editClassLabel', { requestTimeout: 10000 });
+        cy.wait('@editClassLabel');
     });
 
     /**
@@ -99,11 +99,11 @@ describe('Items', () => {
 
             cy.getSettled(`${selectors.root} a:nth(0)`)
             .click()
-            .wait('@editClassLabel', { requestTimeout: 10000 })
+            .wait('@editClassLabel')
             .addClass(selectors.itemClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
             .renameSelectedClass(selectors.itemClassForm, classMovedName);
 
-            cy.wait('@treeRender', { requestTimeout: 10000 });
+            cy.wait('@treeRender');
 
             cy.moveClassFromRoot(
                 selectors.root,
@@ -131,11 +131,11 @@ describe('Items', () => {
             cy.intercept('POST', `**/${ selectors.editClassLabelUrl }`).as('editClassLabel')
             cy.getSettled(`${selectors.root} a:nth(0)`)
             .click()
-            .wait('@editClassLabel', { requestTimeout: 10000 })
+            .wait('@editClassLabel')
             .addClass(selectors.itemClassForm, selectors.treeRenderUrl, selectors.addSubClassUrl)
             .renameSelectedClass(selectors.itemClassForm, className);
 
-            cy.wait('@editClassLabel', { requestTimeout: 10000 });
+            cy.wait('@editClassLabel');
 
             cy.deleteClassFromRoot(
                 selectors.root,

--- a/views/cypress/tests/items-page.spec.js
+++ b/views/cypress/tests/items-page.spec.js
@@ -26,9 +26,7 @@ describe('Items Page', () => {
         cy.loginAsAdmin();
         cy.intercept('POST', '**/edit*').as('edit');
         cy.visit(urls.items);
-        cy.wait('@edit', {
-            requestTimeout: 10000
-        });
+        cy.wait('@edit');
     });
 
     describe('Items page', () => {


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/AUT-1034

We have explicitly defined a specific time for most of our request interception/waiting. 
i.e: .wait('@editItem', { requestTimeout: 10000 }) 

We should make this requestTimeout of 10000ms the norm by defining it as a default in cypress.json and removing each explicit mention of it in our .wait() function calls.

**How to test:**
Run cypress and check that updated tests pass without errors after updating default request timeout.