### PR TITLE
Feature/tr 4339/custom theme in previewer from ClientConfig

### DIFF
--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -63,11 +63,13 @@ define([
             uri: actionContext.id
         };
         const config = _.merge(defaultConfig, module.config());
-
-        previewerFactory(config.provider, config.uri, config.state, {
+        const previewerConfig = _.omit({
             readOnly: false,
-            fullPage: true
-        });
+            fullPage: true,
+            pluginsOptions: config.pluginsOptions
+        }, _.isUndefined);
+
+        previewerFactory(config.provider, config.uri, config.state, previewerConfig);
     });
 
     binder.register('deleteItem', function (actionContext) {


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TR-4339

Base composer: see TAE branch in PR: https://oat-sa.atlassian.net/browse/TR-4339?focusedCommentId=191355

Migration from customer extension PR will add to `tao-enterprise-nfer-enot\config\tao\client_lib_config_registry.conf.php`:
```
...
return new oat\oatbox\config\ConfigurationService(array(
    'config' => array(
        ....
        'taoItems/previewer/factory' => array(
            ...
        ),
        'taoItems/controller/items/action' => array(
            'pluginsOptions' =>  array(
                'itemThemeSwitcher' => array(
                    'activeNamespace' => 'nferEnotThemeEnotMaths'
                )
            )
        ),
        ....        
    )
));

```
