### PR TITLE
fix: set item resource type in form options

### DIFF
--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -1,4 +1,5 @@
 <?php
+
 // phpcs:disable Generic.Files.LineLength
 /**
  * This program is free software; you can redistribute it and/or
@@ -80,7 +81,8 @@ class taoItems_actions_Items extends tao_actions_SaSModule
                         'Items',
                         'taoItems',
                         ['uri' => $uri, 'classUri' => $classUri]
-                    ));
+                    )
+                );
 
                 $this->setData('previewUrl', $this->getClassService()->getPreviewUrl($item));
             }

--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -1,5 +1,5 @@
 <?php
-
+// phpcs:disable Generic.Files.LineLength
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -21,6 +21,7 @@
  *               2012-2018 (update and modification) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
+// phpcs:enable
 
 declare(strict_types=1);
 
@@ -46,6 +47,7 @@ use oat\tao\model\Lists\Business\Validation\DependsOnPropertyValidator;
  * @package taoItems
  * @license GPLv2  http://www.opensource.org/licenses/gpl-2.0.php
  */
+// phpcs:ignore
 class taoItems_actions_Items extends tao_actions_SaSModule
 {
     use OntologyAwareTrait;
@@ -70,7 +72,16 @@ class taoItems_actions_Items extends tao_actions_SaSModule
             if (!empty($uri)) {
                 $item = $this->getResource(tao_helpers_Uri::decode($uri));
                 $this->setData('label', $item->getLabel());
-                $this->setData('authoringUrl', _url('authoring', 'Items', 'taoItems', ['uri' => $uri, 'classUri' => $classUri]));
+
+                $this->setData(
+                    'authoringUrl',
+                    _url(
+                        'authoring',
+                        'Items',
+                        'taoItems',
+                        ['uri' => $uri, 'classUri' => $classUri]
+                    ));
+
                 $this->setData('previewUrl', $this->getClassService()->getPreviewUrl($item));
             }
         }
@@ -337,13 +348,13 @@ class taoItems_actions_Items extends tao_actions_SaSModule
                     $itemModelImpl = $this->getClassService()->getItemModelImplementation($itemModel);
                     $authoringUrl = $itemModelImpl->getAuthoringUrl($item);
                     if (!empty($authoringUrl)) {
-                        LockManager::getImplementation()->setLock($item, $this->getSession()->getUser()->getIdentifier());
+                        LockManager::getImplementation()
+                            ->setLock($item, $this->getSession()->getUser()->getIdentifier());
 
                         return $this->forwardUrl($authoringUrl);
                     }
                 }
                 throw new common_exception_NoImplementation();
-                $this->setData('instanceUri', tao_helpers_Uri::encode($item->getUri(), false));
             } catch (Exception $e) {
                 if ($e instanceof InterruptedActionException) {
                     throw $e;
@@ -351,9 +362,14 @@ class taoItems_actions_Items extends tao_actions_SaSModule
                 $this->setData('error', true);
                 //build clear error or warning message:
                 if (!empty($itemModel) && $itemModel instanceof core_kernel_classes_Resource) {
-                    $errorMsg = __('No item authoring tool available for the selected type of item: %s' . $itemModel->getLabel());
+                    $errorMsg = __(
+                        'No item authoring tool available for the selected type of item: %s'
+                        . $itemModel->getLabel()
+                    );
                 } else {
-                    $errorMsg = __('No item type selected for the current item.') . " {$item->getLabel()} " . __('Please select first the item type!');
+                    $errorMsg = __('No item type selected for the current item.')
+                        . " {$item->getLabel()} "
+                        . __('Please select first the item type!');
                 }
                 $this->setData('errorMsg', $errorMsg);
             }

--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -27,6 +27,7 @@ declare(strict_types=1);
 use oat\oatbox\event\EventManager;
 use oat\generis\model\OntologyRdfs;
 use oat\tao\model\lock\LockManager;
+use oat\tao\model\TaoOntology;
 use oat\taoItems\model\ItemModelStatus;
 use oat\tao\model\accessControl\Context;
 use oat\generis\model\OntologyAwareTrait;
@@ -174,6 +175,10 @@ class taoItems_actions_Items extends tao_actions_SaSModule
                 ]
             );
             $myForm = $formContainer->getForm();
+
+            $myForm->setOptions([
+                'resourceType' => TaoOntology::ITEM_CLASS_URI
+            ]);
 
             if ($hasWriteAccess) {
                 if ($myForm->isSubmited() && $myForm->isValid()) {

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,7 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
+        "oat-sa/extension-tao-mediamanager": ">=12.31.2",
         "oat-sa/generis": ">=15.22",
         "oat-sa/tao-core": ">=50.26.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"

--- a/test/unit/models/classes/media/AssetTreeBuilderTest.php
+++ b/test/unit/models/classes/media/AssetTreeBuilderTest.php
@@ -21,11 +21,10 @@ declare(strict_types=1);
 
 namespace oat\taoItems\test\unit\models\classes\media;
 
-use oat\tao\model\accessControl\AccessControlEnablerInterface;
 use oat\tao\model\media\MediaAsset;
+use oat\tao\model\media\MediaBrowser;
 use oat\tao\model\media\mediaSource\DirectorySearchQuery;
 use oat\taoItems\model\media\AssetTreeBuilder;
-use oat\taoMediaManager\model\MediaSource;
 use tao_helpers_Uri;
 use oat\generis\test\TestCase;
 
@@ -53,7 +52,7 @@ class AssetTreeBuilderTest extends TestCase
         ];
         $search = $this->createMock(DirectorySearchQuery::class);
         $mediaAsset = $this->createMock(MediaAsset::class);
-        $mediaSource = $this->createMock(MediaSource::class);
+        $mediaSource = $this->createMock(MediaBrowser::class);
 
         $search->method('getAsset')
             ->willReturn($mediaAsset);

--- a/test/unit/models/classes/media/AssetTreeBuilderTest.php
+++ b/test/unit/models/classes/media/AssetTreeBuilderTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -83,4 +84,3 @@ class AssetTreeBuilderTest extends TestCase
         );
     }
 }
-

--- a/test/unit/models/classes/media/AssetTreeBuilderTest.php
+++ b/test/unit/models/classes/media/AssetTreeBuilderTest.php
@@ -25,6 +25,7 @@ use oat\tao\model\media\MediaAsset;
 use oat\tao\model\media\MediaBrowser;
 use oat\tao\model\media\mediaSource\DirectorySearchQuery;
 use oat\taoItems\model\media\AssetTreeBuilder;
+use oat\taoMediaManager\model\MediaSource;
 use tao_helpers_Uri;
 use oat\generis\test\TestCase;
 
@@ -52,7 +53,7 @@ class AssetTreeBuilderTest extends TestCase
         ];
         $search = $this->createMock(DirectorySearchQuery::class);
         $mediaAsset = $this->createMock(MediaAsset::class);
-        $mediaSource = $this->createMock(MediaBrowser::class);
+        $mediaSource = $this->createMock(MediaSource::class);
 
         $search->method('getAsset')
             ->willReturn($mediaAsset);

--- a/test/unit/models/classes/media/AssetTreeBuilderTest.php
+++ b/test/unit/models/classes/media/AssetTreeBuilderTest.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 namespace oat\taoItems\test\unit\models\classes\media;
 
 use oat\tao\model\media\MediaAsset;
-use oat\tao\model\media\MediaBrowser;
 use oat\tao\model\media\mediaSource\DirectorySearchQuery;
 use oat\taoItems\model\media\AssetTreeBuilder;
 use oat\taoMediaManager\model\MediaSource;

--- a/test/unit/pack/encoder/Base64fileEncoderTest.php
+++ b/test/unit/pack/encoder/Base64fileEncoderTest.php
@@ -23,10 +23,10 @@ namespace oat\taoItems\test\unit\pack\encoder;
 use oat\generis\test\TestCase;
 use oat\oatbox\filesystem\File;
 use oat\tao\model\media\MediaAsset;
+use oat\tao\model\media\MediaBrowser;
 use oat\tao\model\media\sourceStrategy\HttpSource;
 use oat\taoItems\model\pack\encoders\Base64fileEncoder;
 use oat\taoItems\model\pack\ExceptionMissingAsset;
-use oat\taoMediaManager\model\MediaSource;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -41,7 +41,7 @@ class Base64fileEncoderTest extends TestCase
             ->getMock();
         $stream->method('getContents')->willReturn('value');
 
-        $mediaSource = $this->getMockBuilder(MediaSource::class)
+        $mediaSource = $this->getMockBuilder(MediaBrowser::class)
             ->disableOriginalConstructor()
             ->getMock();
         $mediaSource->method('getFileInfo')->willReturn(['mime' => 'text/css']);

--- a/test/unit/pack/encoder/Base64fileEncoderTest.php
+++ b/test/unit/pack/encoder/Base64fileEncoderTest.php
@@ -64,10 +64,10 @@ class Base64fileEncoderTest extends TestCase
         $mediaAssetHttpSource->method('getMediaIdentifier')->willReturn('value');
 
         return [
-            ['exist.css', 'data:text/css;base64,' . base64_encode('value')],
-            [$mediaAsset, 'data:text/css;base64,' . base64_encode('value')],
-            [$mediaAssetHttpSource, 'value'],
-            ['http://google.com/styles.css', 'http://google.com/styles.css']
+            'data value' => ['value', 'data:text/css;base64,' . base64_encode('value')],
+            'media asset' => [$mediaAsset, 'data:text/css;base64,' . base64_encode('value')],
+            'mediaAssetHttpSource' => [$mediaAssetHttpSource, 'value'],
+            'google' => ['http://google.com/styles.css', 'http://google.com/styles.css']
         ];
     }
 
@@ -78,7 +78,6 @@ class Base64fileEncoderTest extends TestCase
      */
     public function testEncode($data, $expected)
     {
-
         $directoryStorage = $this->getMockBuilder(\tao_models_classes_service_StorageDirectory::class)
             ->disableOriginalConstructor()
             ->getMock();
@@ -91,7 +90,7 @@ class Base64fileEncoderTest extends TestCase
         $file->method('read')->willReturn('value');
         $file->method('getMimeType')->willReturn('text/css');
 
-        $directoryStorage->method('getFile')->with('exist.css')->willReturn($file);
+        $directoryStorage->method('getFile')->with('value')->willReturn($file);
 
         $encoder = new Base64fileEncoder($directoryStorage);
         $this->assertEquals($expected, $encoder->encode($data));


### PR DESCRIPTION
Related to https://github.com/oat-sa/extension-tao-resource-workflow/pull/42

Define Item resourceType in form options

How to reproduce:

- Ensure your instance has taoResourceWorkflow installed
- Create item with content
- Export Item
- Open another environment with taoResourceWorkflow installed
- Import item
- Ensure the item has initially stated and defined in the workflow