### PR TITLE
fix: media manager is braking taoUpdate

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,6 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/extension-tao-mediamanager": ">=12.31.2",
         "oat-sa/generis": ">=15.22",
         "oat-sa/tao-core": ">=50.26.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"

--- a/test/unit/models/classes/media/AssetTreeBuilderTest.php
+++ b/test/unit/models/classes/media/AssetTreeBuilderTest.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 namespace oat\taoItems\test\unit\models\classes\media;
 
 use oat\tao\model\media\MediaAsset;
+use oat\tao\model\media\MediaBrowser;
 use oat\tao\model\media\mediaSource\DirectorySearchQuery;
 use oat\taoItems\model\media\AssetTreeBuilder;
-use oat\taoMediaManager\model\MediaSource;
 use tao_helpers_Uri;
 use oat\generis\test\TestCase;
 
@@ -53,7 +53,7 @@ class AssetTreeBuilderTest extends TestCase
         ];
         $search = $this->createMock(DirectorySearchQuery::class);
         $mediaAsset = $this->createMock(MediaAsset::class);
-        $mediaSource = $this->createMock(MediaSource::class);
+        $mediaSource = $this->createMock(MediaBrowser::class);
 
         $search->method('getAsset')
             ->willReturn($mediaAsset);
@@ -63,9 +63,6 @@ class AssetTreeBuilderTest extends TestCase
 
         $mediaSource->method('getDirectories')
             ->willReturn($data);
-
-        $mediaSource->expects($this->once())
-            ->method('enableAccessControl');
 
         $expectedData = [
             'children' => [


### PR DESCRIPTION
When taoMediaManager is required taoSetup and taoUpdate failing. Revert change