### PR TITLE
feat: add resource transfer logic to support different ACL strategy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,20 @@
             ]
         }
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/oat-sa/tao-core.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/oat-sa/extension-tao-item.git"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/oat-sa/extension-tao-backoffice.git"
+        }
+    ],
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.0.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -58,20 +58,6 @@
             ]
         }
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/oat-sa/tao-core.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/oat-sa/extension-tao-item.git"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/oat-sa/extension-tao-backoffice.git"
-        }
-    ],
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 51.12.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0.x-dev",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.0.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0.x-dev",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.11.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 51.12.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": ">=50.26.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 51.12.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.11.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.22",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.0.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,8 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.23",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as v52.0.0",
+        "oat-sa/generis": ">=15.24",
+        "oat-sa/tao-core": ">=52.1",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,4 @@
 {
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:oat-sa/oatbox-extension-installer.git"
-        }
-    ],
     "name": "oat-sa/extension-tao-item",
     "authors": [
         {
@@ -67,7 +61,7 @@
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
         "oat-sa/generis": ">=15.23",
-        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
+        "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 51.12.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.22",
+        "oat-sa/generis": ">=15.23",
         "oat-sa/tao-core": "dev-feat/RFE-530/integration-branch as 52.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 namespace oat\taoItems\model\Copier;
 
 use oat\generis\model\data\Ontology;
+use oat\tao\model\resources\Service\InstanceCopierProxy;
 use oat\tao\model\TaoOntology;
 use oat\oatbox\event\EventManager;
 use oat\taoItems\model\TaoItemOntology;
@@ -129,6 +130,16 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
                 [
                     TaoOntology::CLASS_URI_ITEM,
                     service(ItemClassCopier::class),
+                ]
+            );
+
+        $services
+            ->get(InstanceCopierProxy::class)
+            ->call(
+                'addInstanceCopier',
+                [
+                    TaoOntology::CLASS_URI_ITEM,
+                    service(InstanceCopier::class . '::ITEMS'),
                 ]
             );
     }

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -77,6 +77,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
             ->args(
                 [
                     service(InstanceMetadataCopier::class),
+                    service(Ontology::SERVICE_ID)
                 ]
             )
             ->call(

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 
 namespace oat\taoItems\model\Copier;
 
+use oat\generis\model\data\Ontology;
 use oat\tao\model\TaoOntology;
 use oat\oatbox\event\EventManager;
 use oat\taoItems\model\TaoItemOntology;
@@ -100,6 +101,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
                     service(ClassMetadataCopier::class),
                     service(InstanceCopier::class . '::ITEMS'),
                     service(ClassMetadataMapper::class),
+                    service(Ontology::SERVICE_ID),
                 ]
             )
             ->call(
@@ -115,6 +117,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
             ->args(
                 [
                     service(ClassCopier::class . '::ITEMS'),
+                    service(Ontology::SERVICE_ID),
                 ]
             );
 

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -90,7 +90,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
             ->call(
                 'withPermissionCopiers',
                 [
-                    tagged_iterator('tao.copier.permissions.instance.items'),
+                    tagged_iterator('tao.copier.permissions'),
                 ]
             );
 
@@ -109,7 +109,7 @@ class CopierServiceProvider implements ContainerServiceProviderInterface
             ->call(
                 'withPermissionCopiers',
                 [
-                    tagged_iterator('tao.copier.permissions.class.items'),
+                    tagged_iterator('tao.copier.permissions'),
                 ]
             );
 

--- a/models/classes/Copier/CopierServiceProvider.php
+++ b/models/classes/Copier/CopierServiceProvider.php
@@ -44,6 +44,9 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\tagged_iterator;
 
+/**
+ * @codeCoverageIgnore
+ */
 class CopierServiceProvider implements ContainerServiceProviderInterface
 {
     public function __invoke(ContainerConfigurator $configurator): void

--- a/models/classes/Copier/ItemClassCopier.php
+++ b/models/classes/Copier/ItemClassCopier.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2022-2023 (original work) Open Assessment Technologies SA.
  *
  * @author Andrei Shapiro <andrei.shapiro@taotesting.com>
  */
@@ -26,22 +26,25 @@ namespace oat\taoItems\model\Copier;
 
 use InvalidArgumentException;
 use core_kernel_classes_Class;
+use oat\generis\model\data\Ontology;
+use oat\tao\model\resources\Command\ResourceTransferCommand;
+use oat\tao\model\resources\Contract\ResourceTransferInterface;
+use oat\tao\model\resources\ResourceTransferResult;
 use oat\tao\model\TaoOntology;
 use oat\tao\model\resources\Contract\ClassCopierInterface;
 
-class ItemClassCopier implements ClassCopierInterface
+class ItemClassCopier implements ClassCopierInterface, ResourceTransferInterface
 {
-    /** @var ClassCopierInterface */
+    /** @var ClassCopierInterface|ResourceTransferInterface */
     private $taoClassCopier;
+    private Ontology $ontology;
 
-    public function __construct(ClassCopierInterface $taoClassCopier)
+    public function __construct(ClassCopierInterface $taoClassCopier, Ontology $ontology)
     {
         $this->taoClassCopier = $taoClassCopier;
+        $this->ontology = $ontology;
     }
 
-    /**
-     * @inheritDoc
-     */
     public function copy(
         core_kernel_classes_Class $class,
         core_kernel_classes_Class $destinationClass
@@ -49,6 +52,13 @@ class ItemClassCopier implements ClassCopierInterface
         $this->assertInItemsRootClass($class);
 
         return $this->taoClassCopier->copy($class, $destinationClass);
+    }
+
+    public function transfer(ResourceTransferCommand $command): ResourceTransferResult
+    {
+        $this->assertInItemsRootClass($this->ontology->getClass($command->getFrom()));
+
+        return $this->taoClassCopier->transfer($command);
     }
 
     private function assertInItemsRootClass(core_kernel_classes_Class $class): void

--- a/models/classes/Copier/ItemClassCopier.php
+++ b/models/classes/Copier/ItemClassCopier.php
@@ -39,19 +39,10 @@ class ItemClassCopier implements ClassCopierInterface, ResourceTransferInterface
     private $taoClassCopier;
     private Ontology $ontology;
 
-    public function __construct(ClassCopierInterface $taoClassCopier, Ontology $ontology)
+    public function __construct(ResourceTransferInterface $taoClassCopier, Ontology $ontology)
     {
         $this->taoClassCopier = $taoClassCopier;
         $this->ontology = $ontology;
-    }
-
-    public function copy(
-        core_kernel_classes_Class $class,
-        core_kernel_classes_Class $destinationClass
-    ): core_kernel_classes_Class {
-        $this->assertInItemsRootClass($class);
-
-        return $this->taoClassCopier->copy($class, $destinationClass);
     }
 
     public function transfer(ResourceTransferCommand $command): ResourceTransferResult
@@ -59,6 +50,22 @@ class ItemClassCopier implements ClassCopierInterface, ResourceTransferInterface
         $this->assertInItemsRootClass($this->ontology->getClass($command->getFrom()));
 
         return $this->taoClassCopier->transfer($command);
+    }
+
+    public function copy(
+        core_kernel_classes_Class $class,
+        core_kernel_classes_Class $destinationClass
+    ): core_kernel_classes_Class {
+        $result = $this->transfer(
+            new ResourceTransferCommand(
+                $class->getUri(),
+                $destinationClass->getUri(),
+                ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+                ResourceTransferCommand::TRANSFER_MODE_COPY
+            )
+        );
+
+        return $this->ontology->getClass($result->getDestination());
     }
 
     private function assertInItemsRootClass(core_kernel_classes_Class $class): void

--- a/test/unit/models/classes/Copier/ItemClassCopierTest.php
+++ b/test/unit/models/classes/Copier/ItemClassCopierTest.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2022-2023 (original work) Open Assessment Technologies SA.
  *
  * @author Andrei Shapiro <andrei.shapiro@taotesting.com>
  */
@@ -26,101 +26,143 @@ namespace oat\taoItems\test\unit\models\classes\Copier;
 
 use InvalidArgumentException;
 use core_kernel_classes_Class;
+use oat\generis\model\data\Ontology;
+use oat\tao\model\resources\Command\ResourceTransferCommand;
+use oat\tao\model\resources\Contract\ResourceTransferInterface;
+use oat\tao\model\resources\ResourceTransferResult;
 use oat\tao\model\TaoOntology;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use oat\taoItems\model\Copier\ItemClassCopier;
-use oat\tao\model\resources\Contract\ClassCopierInterface;
 
 class ItemClassCopierTest extends TestCase
 {
-    /** @var ItemClassCopier */
-    private $sut;
+    private ItemClassCopier $sut;
 
-    /** @var ClassCopierInterface|MockObject */
+    /** @var ResourceTransferInterface|MockObject */
     private $classCopier;
+    /** @var Ontology|MockObject */
+    private $ontology;
 
     protected function setUp(): void
     {
-        $this->classCopier = $this->createMock(ClassCopierInterface::class);
+        $this->classCopier = $this->createMock(ResourceTransferInterface::class);
+        $this->ontology = $this->createMock(Ontology::class);
 
-        $this->sut = new ItemClassCopier($this->classCopier);
+        $this->sut = new ItemClassCopier($this->classCopier, $this->ontology);
+    }
+
+    public function testTransfer(): void
+    {
+        $this->mockClassVerification(true, true);
+
+        $result = new ResourceTransferResult('newClassUri');
+        $command = new ResourceTransferCommand(
+            'classUri',
+            'destinationClassUri',
+            ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+            ResourceTransferCommand::TRANSFER_MODE_COPY
+        );
+
+        $this->classCopier
+            ->expects($this->once())
+            ->method('transfer')
+            ->with($command)
+            ->willReturn($result);
+
+        $this->assertEquals($result, $this->sut->transfer($command));
     }
 
     public function testCopy(): void
     {
-        $rootClass = $this->createMock(core_kernel_classes_Class::class);
+        $class = $this->mockClassVerification(true, true);
+        $destinationClass = $this->createClass('destinationClassUri');
 
-        $class = $this->createMock(core_kernel_classes_Class::class);
-        $class
-            ->expects($this->once())
-            ->method('getClass')
-            ->with(TaoOntology::CLASS_URI_ITEM)
-            ->willReturn($rootClass);
-        $class
-            ->expects($this->once())
-            ->method('equals')
-            ->with($rootClass)
-            ->willReturn(true);
-        $class
-            ->expects($this->never())
-            ->method('isSubClassOf');
-        $class
-            ->expects($this->never())
-            ->method('getUri');
-
-        $destinationClass = $this->createMock(core_kernel_classes_Class::class);
-        $newClass = $this->createMock(core_kernel_classes_Class::class);
+        $result = new ResourceTransferResult('newClassUri');
+        $command = new ResourceTransferCommand(
+            'classUri',
+            'destinationClassUri',
+            ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+            ResourceTransferCommand::TRANSFER_MODE_COPY
+        );
 
         $this->classCopier
             ->expects($this->once())
-            ->method('copy')
-            ->with($class, $destinationClass)
-            ->willReturn($newClass);
+            ->method('transfer')
+            ->with($command)
+            ->willReturn($result);
 
-        $this->assertEquals($newClass, $this->sut->copy($class, $destinationClass));
+        $this->assertSame('newClassUri', $this->sut->copy($class, $destinationClass)->getUri());
     }
 
     public function testCopyInvalidClass(): void
     {
-        $rootClass = $this->createMock(core_kernel_classes_Class::class);
-
-        $classUri = 'classUri';
-
-        $class = $this->createMock(core_kernel_classes_Class::class);
-        $class
-            ->expects($this->once())
-            ->method('getClass')
-            ->with(TaoOntology::CLASS_URI_ITEM)
-            ->willReturn($rootClass);
-        $class
-            ->expects($this->once())
-            ->method('equals')
-            ->with($rootClass)
-            ->willReturn(false);
-        $class
-            ->expects($this->once())
-            ->method('isSubClassOf')
-            ->with($rootClass)
-            ->willReturn(false);
-        $class
-            ->expects($this->once())
-            ->method('getUri')
-            ->willReturn($classUri);
-
-        $this->classCopier
-            ->expects($this->never())
-            ->method('copy');
+        $this->mockClassVerification(false, false);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
             sprintf(
                 'Selected class (%s) is not supported because it is not part of the items root class (%s).',
-                $classUri,
+                'classUri',
                 TaoOntology::CLASS_URI_ITEM
             )
         );
 
-        $this->sut->copy($class, $this->createMock(core_kernel_classes_Class::class));
+        $this->sut->transfer(
+            new ResourceTransferCommand(
+                'classUri',
+                'destinationClassUri',
+                ResourceTransferCommand::ACL_KEEP_ORIGINAL,
+                ResourceTransferCommand::TRANSFER_MODE_COPY
+            )
+        );
+    }
+
+    private function createClass(string $uri): MockObject
+    {
+        $class = $this->createMock(core_kernel_classes_Class::class);
+
+        $class->method('getUri')
+            ->willReturn($uri);
+
+        return $class;
+    }
+
+    private function mockClassVerification(bool $isRootClass, bool $isSubclassOfRoot): MockObject
+    {
+        $rootClass = $this->createClass(TaoOntology::CLASS_URI_ITEM);
+        $class = $this->createClass('classUri');
+        $newClass = $this->createClass('newClassUri');
+
+        $class->expects($this->once())
+            ->method('getClass')
+            ->with(TaoOntology::CLASS_URI_ITEM)
+            ->willReturn($rootClass);
+
+        $class->expects($this->once())
+            ->method('equals')
+            ->with($rootClass)
+            ->willReturn($isRootClass);
+
+        $class->method('isSubClassOf')
+            ->with($rootClass)
+            ->willReturn($isSubclassOfRoot);
+
+        $this->ontology->method('getClass')
+            ->willReturnCallback(
+                function ($uri) use ($class, $newClass) {
+                    if ($uri === 'classUri') {
+                        return $class;
+                    }
+
+                    if ($uri === 'newClassUri') {
+                        return $newClass;
+                    }
+
+                    return null;
+                }
+            );
+
+        return $class;
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/RFE-530
https://oat-sa.atlassian.net/browse/ADF-1424
https://oat-sa.atlassian.net/browse/ADF-1425
https://oat-sa.atlassian.net/browse/ADF-1426
https://oat-sa.atlassian.net/browse/ADF-1427

# Goal

Add dynamic ACL strategy to `Move to` and `Copy to` features

# How to test

- Login to backoffice
- Play with the new ACL options for Items/Assets/Tests

# Related PRs

- https://github.com/oat-sa/tao-core/pull/3776
- https://github.com/oat-sa/extension-tao-mediamanager/pull/462
- https://github.com/oat-sa/extension-tao-test/pull/438
- https://github.com/oat-sa/extension-tao-dac-simple/pull/216
- https://github.com/oat-sa/generis/pull/1036