### PR TITLE
feature/ADF-1419/Restore the release action to v1

### DIFF
--- a/.github/workflows/release_tao_extension.yml
+++ b/.github/workflows/release_tao_extension.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Release
-        uses: oat-sa/extension-release-action@v2
+        uses: oat-sa/extension-release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         with:


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1419

### Summary

Restore the default version for the release action.

### Details

The version was temporarily set to `v2` in order to test and validate the behavior.