### PR TITLE
feat: Delete related resources on QtiTestDeletedEvent

### DIFF
--- a/models/classes/Command/DeleteItemCommand.php
+++ b/models/classes/Command/DeleteItemCommand.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Command;
+
+use core_kernel_classes_Resource;
+
+class DeleteItemCommand
+{
+    private core_kernel_classes_Resource $resource;
+    private bool $deleteRelatedAssets;
+
+    public function __construct(core_kernel_classes_Resource $resource, bool $deleteRelatedAssets = false)
+    {
+        $this->resource = $resource;
+        $this->deleteRelatedAssets = $deleteRelatedAssets;
+    }
+
+    public function getResource(): core_kernel_classes_Resource
+    {
+        return $this->resource;
+    }
+
+    public function mustDeleteRelatedAssets(): bool
+    {
+        return $this->deleteRelatedAssets;
+    }
+}

--- a/models/classes/class.ItemsService.php
+++ b/models/classes/class.ItemsService.php
@@ -158,7 +158,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
             new ItemRemovedEvent(
                 $resource->getUri(),
                 [
-                    ItemRemovedEvent::PAYLOAD_KEY_DELETE_ASSETS => $command->mustDeleteRelatedAssets(),
+                    ItemRemovedEvent::PAYLOAD_KEY_DELETE_RELATED_ASSETS => $command->mustDeleteRelatedAssets(),
                 ]
             )
         );

--- a/models/classes/class.ItemsService.php
+++ b/models/classes/class.ItemsService.php
@@ -19,7 +19,7 @@
  *                         (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor
  *                         (under the project TAO-SUSTAIN & TAO-DEV);
- *               2012-2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT)
+ *               2012-2023 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT)
  */
 
 use oat\taoItems\model\TaoItemOntology;
@@ -35,9 +35,6 @@ use oat\taoItems\model\event\ItemDuplicatedEvent;
 use oat\taoItems\model\event\ItemRemovedEvent;
 use oat\taoItems\model\ItemModelStatus;
 use oat\taoQtiItem\helpers\QtiFile;
-use oat\taoQtiItem\model\qti\Service as QtiItemService;
-use oat\taoQtiItem\model\qti\parser\ElementReferencesExtractor;
-use Psr\Container\ContainerInterface;
 
 /**
  * Service methods to manage the Items business models using the RDF API.

--- a/models/classes/class.ItemsService.php
+++ b/models/classes/class.ItemsService.php
@@ -140,7 +140,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
     public function delete(array $command): void
     {
         $resource = $command['resource']; // @todo
-        
+
         if (LockManager::getImplementation()->isLocked($resource)) {
             $userId = common_session_SessionManager::getSession()->getUser()->getIdentifier();
             LockManager::getImplementation()->releaseLock($resource, $userId);
@@ -157,7 +157,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
                 )
             );
         }
-        
+
         $this->getEventManager()->trigger(
             new ItemRemovedEvent(
                 $resource->getUri(),
@@ -167,7 +167,7 @@ class taoItems_models_classes_ItemsService extends OntologyClassService
             )
         );
     }
-    
+
     /**
      * please call deleteResource() instead
      * @deprecated

--- a/models/classes/event/ItemRemovedEvent.php
+++ b/models/classes/event/ItemRemovedEvent.php
@@ -25,7 +25,8 @@ use JsonSerializable;
 
 class ItemRemovedEvent implements Event, JsonSerializable
 {
-    public const PAYLOAD_KEY_DELETE_ASSETS = 'deleteAssets';
+    public const PAYLOAD_KEY_DELETE_RELATED_ASSETS = 'deleteRelatedAssets';
+    public const PAYLOAD_KEY_ITEM_URI = 'itemUri';
 
     protected string $itemUri;
 
@@ -45,7 +46,7 @@ class ItemRemovedEvent implements Event, JsonSerializable
     public function jsonSerialize()
     {
         return array_merge(
-            ['itemUri' => $this->itemUri],
+            [self::PAYLOAD_KEY_ITEM_URI => $this->itemUri],
             $this->payload
         );
     }

--- a/models/classes/event/ItemRemovedEvent.php
+++ b/models/classes/event/ItemRemovedEvent.php
@@ -15,49 +15,38 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA
- *
+ * Copyright (c) 2016-2023 (original work) Open Assessment Technologies SA.
  */
 
 namespace oat\taoItems\model\event;
 
-use JsonSerializable;
 use oat\oatbox\event\Event;
+use JsonSerializable;
 
 class ItemRemovedEvent implements Event, JsonSerializable
 {
-    /** @var  string */
-    protected $itemUri;
+    public const PAYLOAD_KEY_DELETE_ASSETS = 'deleteAssets';
 
-    /**
-     * @param String $itemUri
-     */
-    public function __construct($itemUri)
+    protected string $itemUri;
+
+    private array $payload;
+
+    public function __construct(string $itemUri, array $payload = [])
     {
         $this->itemUri = $itemUri;
+        $this->payload = $payload;
     }
 
-
-    /**
-     * Return a unique name for this event
-     * @see \oat\oatbox\event\Event::getName()
-     */
     public function getName()
     {
         return get_class($this);
     }
 
-    /**
-     * Specify data which should be serialized to JSON
-     * @link http://php.net/manual/en/jsonserializable.jsonserialize.php
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     * which is a value of any type other than a resource.
-     * @since 5.4.0
-     */
     public function jsonSerialize()
     {
-        return [
-            'itemUri' => $this->itemUri
-        ];
+        return array_merge(
+            ['itemUri' => $this->itemUri],
+            $this->payload
+        );
     }
 }

--- a/test/unit/model/event/ItemRemovedEventTest.php
+++ b/test/unit/model/event/ItemRemovedEventTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\model\event;
+
+use oat\taoItems\model\event\ItemRemovedEvent;
+use PHPUnit\Framework\TestCase;
+
+class ItemRemovedEventTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $event = new ItemRemovedEvent(
+            'itemUri',
+            [
+                ItemRemovedEvent::PAYLOAD_KEY_DELETE_RELATED_ASSETS => true,
+            ]
+        );
+
+        $this->assertSame(ItemRemovedEvent::class, $event->getName());
+        $this->assertSame(
+            [
+                ItemRemovedEvent::PAYLOAD_KEY_ITEM_URI => 'itemUri',
+                ItemRemovedEvent::PAYLOAD_KEY_DELETE_RELATED_ASSETS => true,
+            ],
+            $event->jsonSerialize()
+        );
+    }
+}

--- a/test/unit/models/classes/Command/DeleteItemCommandTest.php
+++ b/test/unit/models/classes/Command/DeleteItemCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\models\classes\Command;
+
+use core_kernel_classes_Resource;
+use oat\taoItems\model\Command\DeleteItemCommand;
+use PHPUnit\Framework\TestCase;
+
+class DeleteItemCommandTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $resource = $this->createMock(core_kernel_classes_Resource::class);
+        $command = new DeleteItemCommand($resource, true);
+
+        $this->assertSame($resource, $command->getResource());
+        $this->assertTrue($command->mustDeleteRelatedAssets());
+    }
+}


### PR DESCRIPTION
**Associated Jira issue:** [PISA25-411](https://oat-sa.atlassian.net/browse/PISA25-411)

- Allow storing an additional payload array on `ItemRemovedEvent`.
- Add a new `delete` method that triggers an event indicating if related assets are to be deleted after deleting an item.

**Related PRs:**
- https://github.com/oat-sa/extension-tao-mediamanager/pull/478
- https://github.com/oat-sa/extension-tao-testqti/pull/2393

[PISA25-411]: https://oat-sa.atlassian.net/browse/PISA25-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ