### PR TITLE
Feat/aut 3479/share items

### DIFF
--- a/actions/class.ItemExport.php
+++ b/actions/class.ItemExport.php
@@ -25,7 +25,7 @@
  */
 
 use oat\tao\model\taskQueue\TaskLogActionTrait;
-use oat\taoItems\model\share\ItemSharingService;
+use oat\taoItems\model\share\ItemSharingTaskCreator;
 
 /**
  * This controller provide the actions to export items
@@ -57,9 +57,9 @@ class taoItems_actions_ItemExport extends tao_actions_Export
             $this->getItemSharingService()->createTask(
                 $this->getPsrRequest()->getParsedBody()
             );
-            $this->setData('message', __('Resources has been exported'));
+            $this->setData('message', __('Items are being shared to Tao Studio'));
         } catch (Exception $e) {
-            $this->setData('errorMessage', __('You do not have the required rights to edit this resource.'));
+            $this->setData('errorMessage', __($e->getMessage()));
         }
 
         $this->setView('form.tpl', 'tao');
@@ -141,8 +141,8 @@ class taoItems_actions_ItemExport extends tao_actions_Export
         return $resources;
     }
 
-    private function getItemSharingService(): ItemSharingService
+    private function getItemSharingService(): ItemSharingTaskCreator
     {
-        return $this->getServiceManager()->getContainer()->get(ItemSharingService::class);
+        return $this->getServiceManager()->getContainer()->get(ItemSharingTaskCreator::class);
     }
 }

--- a/actions/class.ItemExport.php
+++ b/actions/class.ItemExport.php
@@ -24,6 +24,9 @@
  *               2012-2018 (update and modification) Open Assessment Technologies SA;
  */
 
+use oat\tao\model\taskQueue\TaskLogActionTrait;
+use oat\taoItems\model\share\ItemSharingService;
+
 /**
  * This controller provide the actions to export items
  *
@@ -34,6 +37,8 @@
  */
 class taoItems_actions_ItemExport extends tao_actions_Export
 {
+    use TaskLogActionTrait;
+
     /**
      * overwrite the parent index to add the requiresRight for Items only
      *
@@ -44,6 +49,21 @@ class taoItems_actions_ItemExport extends tao_actions_Export
     public function index()
     {
         parent::index();
+    }
+
+    public function shareToTaoStudio()
+    {
+        try {
+            $this->getItemSharingService()->createTask(
+                $this->getPsrRequest()->getParsedBody()
+            );
+            $this->setData('message', __('Resources has been exported'));
+        } catch (Exception $e) {
+            $this->setData('errorMessage', __('You do not have the required rights to edit this resource.'));
+        }
+
+        $this->setView('form.tpl', 'tao');
+        $this->setData('reload', true);
     }
 
     protected function getAvailableExportHandlers(): array
@@ -119,5 +139,10 @@ class taoItems_actions_ItemExport extends tao_actions_Export
         });
 
         return $resources;
+    }
+
+    private function getItemSharingService(): ItemSharingService
+    {
+        return $this->getServiceManager()->getContainer()->get(ItemSharingService::class);
     }
 }

--- a/actions/class.ItemExport.php
+++ b/actions/class.ItemExport.php
@@ -37,8 +37,6 @@ use oat\taoItems\model\share\ItemSharingTaskCreator;
  */
 class taoItems_actions_ItemExport extends tao_actions_Export
 {
-    use TaskLogActionTrait;
-
     /**
      * overwrite the parent index to add the requiresRight for Items only
      *

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -54,6 +54,9 @@
                     <action id="item-export" name="Export" url="/taoItems/ItemExport/index" context="resource" group="tree">
                         <icon id="icon-export"/>
                     </action>
+                    <action id="item-share" name="Share" url="/taoItems/ItemExport/shareToTaoStudio" context="resource" group="tree">
+                        <icon id="icon-export"/>
+                    </action>
                     <action id="item-duplicate" name="Duplicate" url="/taoItems/Items/cloneInstance" context="instance" group="tree" binding="duplicateNode">
                         <icon id="icon-copy"/>
                     </action>

--- a/manifest.php
+++ b/manifest.php
@@ -26,6 +26,7 @@
 
 use oat\tao\model\user\TaoRoles;
 use oat\taoBackOffice\controller\Lists;
+use oat\taoItems\model\share\ItemShareServiceProvider;
 use oat\taoItems\model\user\TaoItemsRoles;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\taoItems\scripts\install\RegisterNpmPaths;
@@ -247,5 +248,6 @@ return [
     ],
     'containerServiceProviders' => [
         CopierServiceProvider::class,
+        ItemShareServiceProvider::class
     ],
 ];

--- a/models/classes/share/ItemShareServiceProvider.php
+++ b/models/classes/share/ItemShareServiceProvider.php
@@ -28,7 +28,6 @@ use oat\oatbox\filesystem\FileSystemService;
 use oat\tao\helpers\FileHelperService;
 use oat\tao\model\taskQueue\QueueDispatcher;
 use oat\taoQtiItem\model\Export\QtiPackage22ExportHandler;
-use oat\taoQtiItem\model\Export\QTIPackedItem22Exporter;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
@@ -39,13 +38,27 @@ class ItemShareServiceProvider implements ContainerServiceProviderInterface
         $services = $configurator->services();
 
         $services
-            ->set(ItemSharingService::class, ItemSharingService::class)
+            ->set(QtiPackage22ExportHandler::class, QtiPackage22ExportHandler::class)
+            ->public();
+
+        $services
+            ->set(ItemSharingTaskCreator::class, ItemSharingTaskCreator::class)
             ->public()
             ->args(
                 [
                     service(QueueDispatcher::class),
                     service(Ontology::SERVICE_ID),
-                    service(FileHelperService::class),
+                    service(FileHelperService::class)
+                ]
+            );
+
+        $services
+            ->set(ItemSharingService::class, ItemSharingService::class)
+            ->public()
+            ->args(
+                [
+                    service(QtiPackage22ExportHandler::class),
+                    service(FileSystemService::SERVICE_ID)
                 ]
             );
     }

--- a/models/classes/share/ItemShareServiceProvider.php
+++ b/models/classes/share/ItemShareServiceProvider.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\share;
+
+use oat\generis\model\data\Ontology;
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\tao\helpers\FileHelperService;
+use oat\tao\model\taskQueue\QueueDispatcher;
+use oat\taoQtiItem\model\Export\QtiPackage22ExportHandler;
+use oat\taoQtiItem\model\Export\QTIPackedItem22Exporter;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+class ItemShareServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(ItemSharingService::class, ItemSharingService::class)
+            ->public()
+            ->args(
+                [
+                    service(QueueDispatcher::class),
+                    service(Ontology::SERVICE_ID),
+                    service(FileHelperService::class),
+                ]
+            );
+    }
+}

--- a/models/classes/share/ItemSharingService.php
+++ b/models/classes/share/ItemSharingService.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\share;
+
+use core_kernel_classes_Resource as Resource;
+use InvalidArgumentException;
+use League\Flysystem\FilesystemInterface;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\extension\AbstractAction;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\tao\helpers\FileHelperService;
+use oat\tao\model\taskQueue\QueueDispatcher;
+use oat\tao\model\taskQueue\Task\AbstractTask;
+use oat\tao\model\taskQueue\Task\TaskInterface;
+use oat\taoItems\model\share\task\ItemSharingTask;
+use oat\taoQtiItem\model\Export\QtiPackage22ExportHandler;
+use oat\taoQtiItem\model\Export\QTIPackedItem22Exporter;
+use tao_helpers_File as FileHelper;
+
+class ItemSharingService
+{
+    use OntologyAwareTrait;
+
+    private $queueDispatcher;
+    private $ontology;
+    private $fileHelperService;
+    public function __construct(
+        QueueDispatcher $queueDispatcher,
+        Ontology $ontology,
+        FileHelperService $fileHelperService,
+    )
+    {
+        $this->queueDispatcher = $queueDispatcher;
+        $this->ontology = $ontology;
+        $this->fileHelperService = $fileHelperService;
+    }
+
+    public function createTask(array $parsedBody): void
+    {
+        $label = $this->getResource($parsedBody['id'])->getLabel();
+        $this->queueDispatcher->createTask(
+            new ItemSharingTask(),
+            [
+                ItemSharingTask::PARAM_EXPORT_DATA => [
+                    ItemSharingTask::LABEL => $label,
+                    ItemSharingTask::INSTANCES => $this->getContentToShare($parsedBody),
+                    ItemSharingTask::DESTINATION => $this->fileHelperService->createTempDir(),
+                    ItemSharingTask::FILENAME => FileHelper::getSafeFileName($parsedBody['id']),
+                    ItemSharingTask::RESOURCE_URI => $parsedBody['id']
+                ],
+            ],
+            sprintf('Sharing resource %s', $label)
+        );
+    }
+
+    private function getContentToShare(array $reqParsedBody): array
+    {
+        if (!isset($reqParsedBody['id'])) {
+            throw new InvalidArgumentException;
+        }
+
+        return $this->getNestedItemsRecursive(
+            $this->ontology->getResource($reqParsedBody['id'])
+        );
+    }
+
+    private function getNestedItemsRecursive(Resource $resource): array
+    {
+        if ($resource->isClass() === false) {
+            return [
+                $resource->getUri()
+            ];
+        }
+
+        return array_column(
+            array_filter($resource->getNestedResources(), function ($item) {
+                return $item['isclass'] === 0;
+            }),
+            'id'
+        );
+    }
+}

--- a/models/classes/share/ItemSharingService.php
+++ b/models/classes/share/ItemSharingService.php
@@ -63,7 +63,7 @@ class ItemSharingService
         );
 
         $this->savePackageExternally(
-            self::SHARED_QTI_ITEMS_PATH . $params[self::PARAM_EXPORT_DATA][self::FILENAME],
+            self::SHARED_QTI_ITEMS_PATH . $params[self::PARAM_EXPORT_DATA][self::FILENAME] . '.zip',
             $report->getData()
         );
 

--- a/models/classes/share/ItemSharingTaskCreator.php
+++ b/models/classes/share/ItemSharingTaskCreator.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\share;
+
+use core_kernel_classes_Resource as Resource;
+use InvalidArgumentException;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\OntologyAwareTrait;
+use oat\tao\helpers\FileHelperService;
+use oat\tao\model\taskQueue\QueueDispatcher;
+use oat\taoItems\model\share\task\ItemSharingTask;
+use tao_helpers_File as FileHelper;
+
+class ItemSharingTaskCreator
+{
+    use OntologyAwareTrait;
+
+    private $queueDispatcher;
+    private $ontology;
+    private $fileHelperService;
+
+    public function __construct(
+        QueueDispatcher $queueDispatcher,
+        Ontology $ontology,
+        FileHelperService $fileHelperService,
+    )
+    {
+        $this->queueDispatcher = $queueDispatcher;
+        $this->ontology = $ontology;
+        $this->fileHelperService = $fileHelperService;
+    }
+
+    public function createTask(array $parsedBody): void
+    {
+        $label = $this->ontology->getResource($parsedBody['id'])->getLabel();
+        $this->queueDispatcher->createTask(
+            new ItemSharingTask(),
+            [
+                ItemSharingService::PARAM_EXPORT_DATA => [
+                    ItemSharingService::LABEL => $label,
+                    ItemSharingService::INSTANCES => $this->getContentToShare($parsedBody),
+                    ItemSharingService::DESTINATION => $this->fileHelperService->createTempDir(),
+                    ItemSharingService::FILENAME => FileHelper::getSafeFileName($parsedBody['id']),
+                    ItemSharingService::RESOURCE_URI => $parsedBody['id']
+                ],
+            ],
+            sprintf('Sharing resource %s', $label)
+        );
+    }
+
+    private function getContentToShare(array $reqParsedBody): array
+    {
+        if (!isset($reqParsedBody['id'])) {
+            throw new InvalidArgumentException;
+        }
+
+        return $this->getNestedItemsRecursive(
+            $this->ontology->getResource($reqParsedBody['id'])
+        );
+    }
+
+    private function getNestedItemsRecursive(Resource $resource): array
+    {
+        if ($resource->isClass() === false) {
+            return [
+                $resource->getUri()
+            ];
+        }
+
+        return array_column(
+            array_filter($resource->getNestedResources(), function ($item) {
+                return $item['isclass'] === 0;
+            }),
+            'id'
+        );
+    }
+}

--- a/models/classes/share/task/ItemSharingTask.php
+++ b/models/classes/share/task/ItemSharingTask.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\share\task;
+
+use Exception;
+use League\Flysystem\FilesystemInterface;
+use oat\oatbox\extension\AbstractAction;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\tao\model\taskQueue\TaskLogActionTrait;
+use oat\taoQtiItem\model\Export\QtiPackage22ExportHandler;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class ItemSharingTask extends AbstractAction
+{
+    use ContainerAwareTrait;
+
+    const PARAM_EXPORT_DATA = 'export_data';
+    const LABEL = 'label';
+    const INSTANCES = 'instances';
+    const DESTINATION = 'destination';
+    const FILENAME = 'filename';
+    const RESOURCE_URI = 'uri';
+    const REMOTE_QTI_ITEM_FILESYSTEM_ID = 'remoteQTIItemFilesystem';
+    const SHARED_QTI_ITEMS_PATH = 'shared/qti-items/';
+
+    public function __invoke($params)
+    {
+        try {
+            $report = $this->getExporter()->export(
+                $params[self::PARAM_EXPORT_DATA],
+                $params[self::PARAM_EXPORT_DATA][self::DESTINATION]
+            );
+
+            $this->savePackageExternally(
+                self::SHARED_QTI_ITEMS_PATH . $params[self::PARAM_EXPORT_DATA][self::FILENAME],
+                $report->getData()
+            );
+
+            $report->setMessage(__('Resource(s) successfully shared.'));
+
+        } catch (Exception $exception) {
+
+        }
+
+        return $report;
+    }
+
+    protected function getExporter(): QtiPackage22ExportHandler
+    {
+        return new QtiPackage22ExportHandler();
+    }
+
+    /**
+     * @return object|null
+     */
+    private function getFileSystem(): FilesystemInterface
+    {
+        return $this->getServiceManager()
+            ->getContainer()
+            ->get(FileSystemService::SERVICE_ID)
+            ->getFileSystem(self::REMOTE_QTI_ITEM_FILESYSTEM_ID);
+    }
+
+    private function savePackageExternally(string $path, string $qtiPackage): void
+    {
+        if (!$this->getFileSystem()->putStream($path, fopen($qtiPackage, 'r'))) {
+            throw new Exception('Could not save the package externally');
+        }
+    }
+
+    private function getExternalPath(): string
+    {
+        return sprintf(self::SHARED_QTI_ITEMS_PATH);
+    }
+}

--- a/test/unit/models/classes/share/ItemSharingServiceTest.php
+++ b/test/unit/models/classes/share/ItemSharingServiceTest.php
@@ -1,0 +1,174 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\models\classes\share;
+
+use InvalidArgumentException;
+use League\Flysystem\FilesystemInterface;
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\oatbox\filesystem\FileSystemService;
+use oat\oatbox\reporting\Report;
+use oat\taoItems\model\share\ItemSharingService;
+use oat\taoQtiItem\model\Export\QtiPackage22ExportHandler;
+use PHPUnit\Framework\TestCase;
+
+class ItemSharingServiceTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+    private $subject;
+    public function setUp(): void
+    {
+        $this->exporterHandlerMock = $this->createMock(QtiPackage22ExportHandler::class);
+        $this->fileSystemServiceMock = $this->createMock(FileSystemService::class);
+        $this->fileSystemMock = $this->createMock(FilesystemInterface::class);
+
+        $this->subject = new ItemSharingService(
+            $this->exporterHandlerMock,
+            $this->fileSystemServiceMock
+        );
+    }
+
+    public function testShareItems()
+    {
+        $reportMock = $this->createMock(Report::class);
+
+        $this->exporterHandlerMock
+            ->expects($this->once())
+            ->method('export')
+            ->willReturn($reportMock);
+
+        $reportMock
+            ->expects($this->once())
+            ->method('getData')
+            ->willReturn('./');
+
+        $this->fileSystemServiceMock
+            ->expects($this->once())
+            ->method('getFileSystem')
+            ->willReturn($this->fileSystemMock);
+
+        $this->fileSystemMock
+            ->expects($this->once())
+            ->method('putStream')
+            ->willReturn(true);
+
+        $result = $this->subject->shareItems(
+            [
+                ItemSharingService::PARAM_EXPORT_DATA => [
+                    ItemSharingService::LABEL => 'Shared Resource Label',
+                    ItemSharingService::INSTANCES => [
+                        'http://tao.com/taoQtiItem.rdf#i1234',
+                        'http://tao.com/taoQtiItem.rdf#i5678'
+                    ],
+                    ItemSharingService::DESTINATION => 'path/to/destination',
+                    ItemSharingService::FILENAME => 'filename',
+                    ItemSharingService::RESOURCE_URI => 'http://tao.com/taoQtiItem.rdf#i4321'
+                ]
+            ]
+        );
+
+        self::assertInstanceOf(Report::class, $result);
+    }
+
+    /**
+     * @dataProvider invalidParamsProvider
+     */
+    public function testShareItemsWithException($params)
+    {
+        $this->exporterHandlerMock
+            ->expects($this->never())
+            ->method('export');
+
+        $this->fileSystemServiceMock
+            ->expects($this->never())
+            ->method('getFileSystem');
+
+        $this->fileSystemMock->expects($this->never())
+            ->method('put');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->subject->shareItems($params);
+    }
+
+    public function invalidParamsProvider()
+    {
+        return [
+            'Missing export data' => [
+                [
+                    ItemSharingService::LABEL => 'test',
+                    ItemSharingService::INSTANCES => [
+                        'test'
+                    ]
+                ]
+            ],
+            'Missing label' => [
+                [
+                    ItemSharingService::PARAM_EXPORT_DATA => [
+                        ItemSharingService::INSTANCES => [
+                            'test'
+                        ]
+                    ]
+                ]
+            ],
+            'Missing instances' => [
+                [
+                    ItemSharingService::PARAM_EXPORT_DATA => [
+                        ItemSharingService::LABEL => 'test',
+                    ]
+                ]
+            ],
+            'Missing destination' => [
+                [
+                    ItemSharingService::PARAM_EXPORT_DATA => [
+                        ItemSharingService::LABEL => 'test',
+                        ItemSharingService::INSTANCES => [
+                            'test'
+                        ]
+                    ]
+                ]
+            ],
+            'Missing filename' => [
+                [
+                    ItemSharingService::PARAM_EXPORT_DATA => [
+                        ItemSharingService::LABEL => 'test',
+                        ItemSharingService::INSTANCES => [
+                            'test'
+                        ],
+                        ItemSharingService::DESTINATION => 'test'
+                    ]
+                ]
+            ],
+            'Missing resource uri' => [
+                [
+                    ItemSharingService::PARAM_EXPORT_DATA => [
+                        ItemSharingService::LABEL => 'test',
+                        ItemSharingService::INSTANCES => [
+                            'test'
+                        ],
+                        ItemSharingService::DESTINATION => 'test',
+                        ItemSharingService::FILENAME => 'test'
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/test/unit/models/classes/share/ItemSharingTaskCreator.php
+++ b/test/unit/models/classes/share/ItemSharingTaskCreator.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\models\classes\share;
+
+use oat\generis\model\data\Ontology;
+use oat\generis\test\OntologyMockTrait;
+use oat\tao\helpers\FileHelperService;
+use oat\tao\model\taskQueue\QueueDispatcher;
+use oat\taoItems\model\share\ItemSharingTaskCreator;
+use PHPUnit\Framework\TestCase;
+use core_kernel_classes_Resource as Resource;
+
+class ItemSharingTaskCreatorTest extends TestCase
+{
+    use OntologyMockTrait;
+    private $queueDispatcherMock;
+    private $ontologyMock;
+    private $fileHelperServiceMock;
+    private $subject;
+    protected function setUp(): void
+    {
+        $this->queueDispatcherMock = $this->createMock(QueueDispatcher::class);
+        $this->ontologyMock = $this->createMock(Ontology::class);
+        $this->fileHelperServiceMock = $this->createMock(FileHelperService::class);
+        $this->ontologyMock = $this->getOntologyMock();
+
+        $this->subject = new ItemSharingTaskCreator(
+            $this->queueDispatcherMock,
+            $this->ontologyMock,
+            $this->fileHelperServiceMock
+        );
+    }
+
+    public function testCreateTask(): void
+    {
+        $resourceMock = $this->createMock(Resource::class);
+
+        $this->ontologyMock
+            ->expects($this->once())
+            ->method('getResource')
+            ->with('SomeUniqueResourceUri')
+            ->willReturn($resourceMock);
+
+        $resourceMock->expects($this->once())
+            ->method('getLabel')
+            ->willReturn('SomeLabel');
+
+        $this->queueDispatcherMock
+            ->expects($this->once())
+            ->method('createTask')
+            ->with(
+                $this->anything(),
+                [
+                    'exportData' => [
+                        'label' => 'SomeLabel',
+                        'instances' => $this->anything(),
+                        'destination' => $this->anything(),
+                        'filename' => $this->anything(),
+                        'resourceUri' => 'SomeUniqueResourceUri',
+                    ],
+                ],
+                'Sharing resource SomeLabel'
+            );
+
+
+        $parsedBody = [
+            'id' => 'SomeUniqueResourceUri',
+        ];
+
+        $this->subject->createTask($parsedBody);
+    }
+}


### PR DESCRIPTION
This will allow user to share items or item from Tao 3.x to external Storage defined by `remoteQTIItemFilesystem`

For testing purpose we can use local storage adapter:

```
<?php
return new oat\oatbox\filesystem\FileSystemService(array(
    'filesPath' => '/var/www/html/data/',
    'adapters' => array(
        'default' => array(
            'class' => 'Local',
            'options' => array(
                'root' => '/var/www/html/data/'
            )
        ),
        'externalStorage' => array(
            'class' => 'Local',
            'options' => array(
                'root' => '/var/www/html/externalStorage/'
            )
        ),
        'memory' => array(
            'class' => 'League\Flysystem\Memory\MemoryAdapter'
        )
    ),
    'dirs' => array(
        (...),
        'remoteQTIItemFilesystem' => 'externalStorage'
    )
));
```

When user clicks on `Share` button he will create task that will export and save item(s) into external storage defined by `remoteQTIItemFilesystem`

<img width="1218" alt="Screenshot 2024-01-26 at 12 31 02" src="https://github.com/oat-sa/extension-tao-item/assets/16231681/fbb74a5a-1d83-4951-81e2-850a335d5377">


Uploading Screenshare - 2024-01-26 12_46_32 PM.mp4…
