### PR TITLE
fix: Rest endpoint providing item class list

### DIFF
--- a/actions/class.RestItems.php
+++ b/actions/class.RestItems.php
@@ -18,7 +18,6 @@
  */
 
 use oat\tao\model\routing\AnnotationReader\security;
-use oat\taoItems\model\search\ItemClassListService;
 
 /**
  *
@@ -36,18 +35,6 @@ class taoItems_actions_RestItems extends tao_actions_CommonRestModule
         //The service taht implements or inherits get/getAll/getRootClass ... for that particular type of resources
         $this->service = taoItems_models_classes_CrudItemsService::singleton();
     }
-
-    public function getItemClasses()
-    {
-
-           $this->returnJson(
-            $this->getItemClassListService()->getList(
-                $this->getGetParameter('q'),
-                $this->getGetParameter('page')
-            )
-        );
-    }
-
     /**
      * Optionnaly a specific rest controller may declare
      * aliases for parameters used for the rest communication
@@ -73,10 +60,5 @@ class taoItems_actions_RestItems extends tao_actions_CommonRestModule
         */
 
         ];
-    }
-
-    private function getItemClassListService(): ItemClassListService
-    {
-        return $this->getServiceManager()->getContainer()->get(ItemClassListService::class);
     }
 }

--- a/actions/class.RestItems.php
+++ b/actions/class.RestItems.php
@@ -18,6 +18,7 @@
  */
 
 use oat\tao\model\routing\AnnotationReader\security;
+use oat\taoItems\model\search\ItemClassListService;
 
 /**
  *
@@ -34,6 +35,17 @@ class taoItems_actions_RestItems extends tao_actions_CommonRestModule
         parent::__construct();
         //The service taht implements or inherits get/getAll/getRootClass ... for that particular type of resources
         $this->service = taoItems_models_classes_CrudItemsService::singleton();
+    }
+
+    public function getItemClasses()
+    {
+
+           $this->returnJson(
+            $this->getItemClassListService()->getList(
+                $this->getGetParameter('q'),
+                $this->getGetParameter('page')
+            )
+        );
     }
 
     /**
@@ -61,5 +73,10 @@ class taoItems_actions_RestItems extends tao_actions_CommonRestModule
         */
 
         ];
+    }
+
+    private function getItemClassListService(): ItemClassListService
+    {
+        return $this->getServiceManager()->getContainer()->get(ItemClassListService::class);
     }
 }

--- a/actions/class.RestItems.php
+++ b/actions/class.RestItems.php
@@ -35,6 +35,7 @@ class taoItems_actions_RestItems extends tao_actions_CommonRestModule
         //The service taht implements or inherits get/getAll/getRootClass ... for that particular type of resources
         $this->service = taoItems_models_classes_CrudItemsService::singleton();
     }
+
     /**
      * Optionnaly a specific rest controller may declare
      * aliases for parameters used for the rest communication

--- a/actions/class.SaSItems.php
+++ b/actions/class.SaSItems.php
@@ -161,7 +161,6 @@ class taoItems_actions_SaSItems extends taoItems_actions_Items
 
     public function getItemClasses()
     {
-
         $this->returnJson(
             $this->getItemClassListService()->getList(
                 $this->getGetParameter('q'),

--- a/actions/class.SaSItems.php
+++ b/actions/class.SaSItems.php
@@ -24,6 +24,7 @@
  */
 
 use oat\generis\model\OntologyRdfs;
+use oat\taoItems\model\search\ItemClassListService;
 use tao_helpers_form_FormContainer as FormContainer;
 
 /**
@@ -158,11 +159,27 @@ class taoItems_actions_SaSItems extends taoItems_actions_Items
         $this->setView('view.tpl');
     }
 
+    public function getItemClasses()
+    {
+
+        $this->returnJson(
+            $this->getItemClassListService()->getList(
+                $this->getGetParameter('q'),
+                $this->getGetParameter('page')
+            )
+        );
+    }
+
     /**
      * Load the standalone mode
      */
     protected function loadStandaloneMode()
     {
         tao_helpers_Context::load('STANDALONE_MODE');
+    }
+
+    private function getItemClassListService(): ItemClassListService
+    {
+        return $this->getServiceManager()->getContainer()->get(ItemClassListService::class);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     },
     "require": {
         "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-        "oat-sa/generis": ">=15.24",
+        "oat-sa/generis": ">=15.36.1",
         "oat-sa/tao-core": ">=53.0.0",
         "oat-sa/extension-tao-backoffice": ">=6.0.0"
     },

--- a/manifest.php
+++ b/manifest.php
@@ -26,6 +26,8 @@
 
 use oat\tao\model\user\TaoRoles;
 use oat\taoBackOffice\controller\Lists;
+use oat\taoItems\model\search\ItemClassListService;
+use oat\taoItems\model\search\ItemClassListServiceProvider;
 use oat\taoItems\model\user\TaoItemsRoles;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\taoItems\scripts\install\RegisterNpmPaths;
@@ -202,6 +204,11 @@ return [
         ],
         [
             AccessRule::GRANT,
+            TaoItemsRoles::ITEM_IMPORTER,
+            ['ext' => 'taoItems', 'mod' => 'RestItem', 'act' => 'getItemClasses'],
+        ],
+        [
+            AccessRule::GRANT,
             TaoItemsRoles::ITEM_DELETER,
             ['ext' => 'taoItems', 'mod' => 'Items', 'act' => 'deleteItem'],
         ],
@@ -247,5 +254,6 @@ return [
     ],
     'containerServiceProviders' => [
         CopierServiceProvider::class,
+        ItemClassListServiceProvider::class
     ],
 ];

--- a/models/classes/search/ItemClassListService.php
+++ b/models/classes/search/ItemClassListService.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\search;
+
+use common_persistence_Manager;
+use core_kernel_classes_Resource;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use oat\generis\model\OntologyRdfs;
+use oat\generis\persistence\PersistenceManager;
+use oat\tao\model\TaoOntology;
+
+class ItemClassListService
+{
+    const CLASS_LIST_LIMIT = 10;
+    private ComplexSearchService $complexSearchService;
+    private Ontology $ontology;
+    public function __construct(ComplexSearchService $complexSearchService, Ontology $ontology)
+    {
+        $this->complexSearchService = $complexSearchService;
+        $this->ontology = $ontology;
+    }
+
+    public function getList(string $query, string $page): array
+    {
+        $page = (int) $page;
+        $root = $this->ontology->getClass(TaoOntology::CLASS_URI_ITEM);
+        $basicQueryParameters = [
+            'recursive' => true,
+            'like' => true,
+            'onlyClass' => true
+        ];
+
+        $query = [
+            OntologyRdfs::RDFS_LABEL => $query
+        ];
+
+        $searchResult = $root->searchInstances(
+            $query,
+            $this->getDynamicQueryParameters($page, $basicQueryParameters)
+        );
+
+        $result['total'] = $root->countInstances($query, $basicQueryParameters) ?? 0;
+        $result['items'] = [];
+
+        foreach ($searchResult as $row) {
+            $result['items'][] = [
+                'id' => $row->getUri(),
+                'uri' => $row->getUri(),
+                'text' => $row->getLabel(),
+                'path' => $this->getListElementText($row)
+            ];
+        }
+        return $result;
+    }
+
+    private function getListElementText(core_kernel_classes_Resource $row): string
+    {
+        $displayText = '';
+        foreach ($row->getParentClassesIds() as $parent) {
+            if ($parent !== TaoOntology::CLASS_URI_ITEM) {
+                $displayText .= $this->ontology->getResource($parent)->getLabel();
+                $displayText .= '/';
+            }
+        }
+
+        $displayText .= $row->getLabel();
+        return $displayText;
+    }
+
+    private function getDynamicQueryParameters(int $page, array $basicQueryParameters)
+    {
+        return array_merge(
+            $basicQueryParameters,
+            [
+                'limit' => self::CLASS_LIST_LIMIT,
+                'offset' => ($page - 1) * self::CLASS_LIST_LIMIT
+            ]
+        );
+    }
+
+}

--- a/models/classes/search/ItemClassListService.php
+++ b/models/classes/search/ItemClassListService.php
@@ -30,7 +30,7 @@ use oat\tao\model\TaoOntology;
 
 class ItemClassListService
 {
-    const CLASS_LIST_LIMIT = 10;
+    private const CLASS_LIST_LIMIT = 10;
     private ComplexSearchService $complexSearchService;
     private Ontology $ontology;
     public function __construct(ComplexSearchService $complexSearchService, Ontology $ontology)
@@ -96,5 +96,4 @@ class ItemClassListService
             ]
         );
     }
-
 }

--- a/models/classes/search/ItemClassListService.php
+++ b/models/classes/search/ItemClassListService.php
@@ -22,12 +22,10 @@ declare(strict_types=1);
 
 namespace oat\taoItems\model\search;
 
-use common_persistence_Manager;
 use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\generis\model\OntologyRdfs;
-use oat\generis\persistence\PersistenceManager;
 use oat\tao\model\TaoOntology;
 
 class ItemClassListService

--- a/models/classes/search/ItemClassListServiceProvider.php
+++ b/models/classes/search/ItemClassListServiceProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\search;
+
+use oat\generis\model\data\Ontology;
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+class ItemClassListServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+        $services->set(ItemClassListService::class, ItemClassListService::class)
+            ->args([
+                service(ComplexSearchService::SERVICE_ID),
+                service(Ontology::SERVICE_ID),
+            ])
+            ->public();
+    }
+}


### PR DESCRIPTION
Allow endpoint to provide list of item classes with simple query and page control.

New endpoint:
`taoItems/RestItems/getItemClasses?q=item&page=1`

