### PR TITLE
Fix: Previewer module config

### DIFF
--- a/views/js/previewer/factory.js
+++ b/views/js/previewer/factory.js
@@ -44,8 +44,8 @@ define([
      * @param {Object} [config.previewers] - Optionally load static adapters. By default take them from the module's config.
      * @returns {Promise}
      */
-    function previewerFactory(type, uri, state, config) {
-        config = Object.assign({}, module.config(), config || {});
+    function previewerFactory(type, uri, state, config = {}) {
+        Object.assign(config, module.config());
         return providerLoaderFactory()
             .addList(config.previewers)
             .load(context.bundle)


### PR DESCRIPTION
Unit test was failing:
<img width="783" alt="Screenshot 2024-05-24 at 10 59 59" src="https://github.com/oat-sa/extension-tao-item/assets/43652944/387ea204-e435-4be6-a47a-42fb31b22b35">

CI action has been failing because of this for 4 months! https://github.com/oat-sa/extension-tao-item/actions/workflows/continuous-integration.yaml

---

The problem was an incorrect refactoring while removing lodash [here](https://github.com/oat-sa/extension-tao-item/commit/4bc33ae8aa947faa8ff11a44cadda4f69a4e223f#diff-ddd12f9912e2406f34d1481cd851e63d4c249c8fcc8703f940b6d4d62d7d26e7).

Fix: the `config` received by the previewerFactory _should be_ mutated, _not_ reassigned.

To test: `npx grunt connect:test taoitemstest`