### PR TITLE
Fix: call __() without typo

### DIFF
--- a/actions/class.ItemContent.php
+++ b/actions/class.ItemContent.php
@@ -161,7 +161,7 @@ class taoItems_actions_ItemContent extends tao_actions_CommonModule
             $formatter->withBody(['error' => $e->getMessage()]);
         } catch (common_Exception $e) {
             $this->logWarning($e->getMessage());
-            $formatter->withBody(['error' => _('Unable to upload file')]);
+            $formatter->withBody(['error' => __('Unable to upload file')]);
         }
 
         $this->setResponse($formatter->format($this->getPsrResponse()));


### PR DESCRIPTION
Call to `_()` threw an error when uploading a file. Looks like a simple typo.

Before fix, a certain type of upload error was invisible to user. Now it manifests as a red notification message.