### PR TITLE
Feature/ADF-1695/Show multiple preview buttons

### DIFF
--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 - 2024 (original work) Open Assessment Techniologies SA
+ * Copyright (c) 2014 - 2024 (original work) Open Assessment Technologies SA
  *
  */
 define([
@@ -34,7 +34,7 @@ define([
     'tpl!taoItems/controller/items/tpl/relatedTestsPopup',
     'tpl!taoItems/controller/items/tpl/relatedClassTestsPopup',
     'tpl!taoItems/controller/items/tpl/forbiddenClassAction',
-    'css!taoItems/controller/items/css/relatedTestsPopup.css',
+    'css!taoItems/controller/items/css/relatedTestsPopup.css'
 ], function (
     _,
     $,
@@ -63,14 +63,17 @@ define([
             uri: actionContext.id
         };
         const config = _.merge(defaultConfig, module.config());
-        const previewerConfig = _.omit({
-            readOnly: false,
-            fullPage: true,
-            pluginsOptions: config.pluginsOptions
-        }, _.isUndefined);
+        const previewerConfig = _.omit(
+            {
+                readOnly: false,
+                fullPage: true,
+                pluginsOptions: config.pluginsOptions
+            },
+            _.isUndefined
+        );
         const getProvider = id => {
             if (!id || !config.providers) {
-                return config.provider
+                return config.provider;
             }
             const previewerId = parseInt(`${id}`.split('-').pop(), 10) || 0;
             if (!config.providers[previewerId]) {
@@ -86,8 +89,7 @@ define([
             checkRelations({
                 sourceId: actionContext.id,
                 type: 'item'
-            })
-            .then((responseRelated) => {
+            }).then(responseRelated => {
                 const relatedTests = responseRelated.data.relations;
                 const name = prepareName($('a.clicked', actionContext.tree).text().trim());
                 if (relatedTests.length === 0) {
@@ -103,8 +105,8 @@ define([
                             number: relatedTests.length,
                             numberOther: relatedTests.length - 3 > 0 ? relatedTests.length - 3 : 0,
                             tests: relatedTests.length <= 3 ? relatedTests : relatedTests.slice(0, 3),
-                            multiple:  relatedTests.length > 1,
-                            multipleOthers: relatedTests.length - 3 > 1,
+                            multiple: relatedTests.length > 1,
+                            multipleOthers: relatedTests.length - 3 > 1
                         }),
                         () => accept(actionContext, this.url, resolve, reject),
                         () => cancel(reject)
@@ -120,38 +122,38 @@ define([
                 classId: actionContext.id,
                 type: 'item'
             })
-            .then((responseRelated) => {
-                const relatedTests = responseRelated.data.relations;
-                const name = prepareName($('a.clicked', actionContext.tree).text().trim());
-                if (relatedTests.length === 0) {
-                    confirmDeleteDialog(
-                        __('Are you sure you want to delete the class %s and all of its content?', `<b>${name}</b>`),
-                        () => accept(actionContext, this.url, resolve, reject),
-                        () => cancel(reject)
-                    );
-                } else {
-                    confirmDeleteDialog(
-                        relatedClassTestsPopupTpl({
-                            name,
-                            number: relatedTests.length,
-                            numberOther: relatedTests.length - 3 > 0 ? relatedTests.length - 3 : 0,
-                            tests: relatedTests.length <= 3 ? relatedTests : relatedTests.slice(0, 3),
-                            multiple:  relatedTests.length > 1,
-                            multipleOthers: relatedTests.length - 3 > 1,
-                        }),
-                        () => accept(actionContext, this.url, resolve, reject),
-                        () => cancel(reject)
-                    );
-                }
-            })
-            .catch(errorObject => {
-                if (errorObject.response.code === 999) {
-                    alertDialog(
-                        forbiddenClassActionTpl(),
-                        () => cancel(reject)
-                    );
-                }
-            });
+                .then(responseRelated => {
+                    const relatedTests = responseRelated.data.relations;
+                    const name = prepareName($('a.clicked', actionContext.tree).text().trim());
+                    if (relatedTests.length === 0) {
+                        confirmDeleteDialog(
+                            __(
+                                'Are you sure you want to delete the class %s and all of its content?',
+                                `<b>${name}</b>`
+                            ),
+                            () => accept(actionContext, this.url, resolve, reject),
+                            () => cancel(reject)
+                        );
+                    } else {
+                        confirmDeleteDialog(
+                            relatedClassTestsPopupTpl({
+                                name,
+                                number: relatedTests.length,
+                                numberOther: relatedTests.length - 3 > 0 ? relatedTests.length - 3 : 0,
+                                tests: relatedTests.length <= 3 ? relatedTests : relatedTests.slice(0, 3),
+                                multiple: relatedTests.length > 1,
+                                multipleOthers: relatedTests.length - 3 > 1
+                            }),
+                            () => accept(actionContext, this.url, resolve, reject),
+                            () => cancel(reject)
+                        );
+                    }
+                })
+                .catch(errorObject => {
+                    if (errorObject.response.code === 999) {
+                        alertDialog(forbiddenClassActionTpl(), () => cancel(reject));
+                    }
+                });
         });
     });
 
@@ -192,14 +194,16 @@ define([
             } else {
                 if (response.success && !response.deleted) {
                     $(actionContext.tree).trigger('refresh.taotree');
-                    reject(response.msg
-                           || response.message
-                           || __('Unable to delete the selected resource because you do not have the required rights to delete part of its content.'));
+                    reject(
+                        response.msg ||
+                            response.message ||
+                            __(
+                                'Unable to delete the selected resource because you do not have the required rights to delete part of its content.'
+                            )
+                    );
                 }
 
-                reject(response.msg
-                       || response.message
-                       || __('Unable to delete the selected resource'));
+                reject(response.msg || response.message || __('Unable to delete the selected resource'));
             }
         });
     }

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014 - 2019 (original work) Open Assessment Techniologies SA
+ * Copyright (c) 2014 - 2024 (original work) Open Assessment Techniologies SA
  *
  */
 define([
@@ -68,8 +68,17 @@ define([
             fullPage: true,
             pluginsOptions: config.pluginsOptions
         }, _.isUndefined);
-
-        previewerFactory(config.provider, config.uri, config.state, previewerConfig);
+        const getProvider = id => {
+            if (!id || !config.providers) {
+                return config.provider
+            }
+            const previewerId = parseInt(`${id}`.split('-').pop(), 10) || 0;
+            if (!config.providers[previewerId]) {
+                return config.provider;
+            }
+            return config.providers[previewerId].id;
+        };
+        previewerFactory(getProvider(this.id) || 'qtiItem', config.uri, config.state, previewerConfig);
     });
 
     binder.register('deleteItem', function (actionContext) {

--- a/views/js/controller/items/edit.js
+++ b/views/js/controller/items/edit.js
@@ -15,31 +15,30 @@
  *
  * Copyright (c) 2014-2024 (original work) Open Assessment Technologies SA;
  */
-define([
-    'jquery',
-    'i18n',
-    'module',
-    'layout/actions',
-    'ui/lock',
-    'layout/section'
-],
-function($, __, module, actions, lock, section){
+define(['jquery', 'i18n', 'module', 'layout/actions', 'ui/lock', 'layout/section'], function (
+    $,
+    __,
+    module,
+    actions,
+    lock,
+    section
+) {
     'use strict';
 
     /**
      * The item properties controller
      */
     var editItemController = {
-
         /**
          * Controller entry point
          */
         start() {
             const config = module.config();
+            const maxButtons = 10; // arbitrary value for the max number of buttons
 
             const getPreviewId = idx => `item-preview${idx ? `-${idx}` : ''}`;
-            const previewActions = []
-            for (let i = 0; i < 10; i++) {
+            const previewActions = [];
+            for (let i = 0; i < maxButtons; i++) {
                 const action = actions.getBy(getPreviewId(i));
                 if (!action) {
                     break;
@@ -48,27 +47,25 @@ function($, __, module, actions, lock, section){
             }
             previewActions.forEach(previewAction => {
                 previewAction.state.disabled = !config.isPreviewEnabled;
-            })
+            });
 
             const authoringAction = actions.getBy('item-authoring');
-            if(authoringAction){
+            if (authoringAction) {
                 authoringAction.state.disabled = !config.isAuthoringEnabled;
             }
             actions.updateState();
 
-            $('#lock-box').each(function() {
+            $('#lock-box').each(function () {
                 lock($(this)).register();
             });
 
             //some of the others sections (like the authoring) might have an impact
             //on the state of the other actions, so we reload when we come back
-            section
-                .off('show')
-                .on('show', sectionContext => {
-                    if(sectionContext.id === 'manage_items'){
-                        actions.exec('item-properties');
-                    }
-                });
+            section.off('show').on('show', sectionContext => {
+                if (sectionContext.id === 'manage_items') {
+                    actions.exec('item-properties');
+                }
+            });
         }
     };
 

--- a/views/js/controller/items/edit.js
+++ b/views/js/controller/items/edit.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2019 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2014-2024 (original work) Open Assessment Technologies SA;
  */
 define([
     'jquery',
@@ -37,12 +37,20 @@ function($, __, module, actions, lock, section){
         start() {
             const config = module.config();
 
-            const previewAction = actions.getBy('item-preview');
-            const authoringAction = actions.getBy('item-authoring');
-
-            if(previewAction){
-                previewAction.state.disabled = !config.isPreviewEnabled;
+            const getPreviewId = idx => `item-preview${idx ? `-${idx}` : ''}`;
+            const previewActions = []
+            for (let i = 0; i < 10; i++) {
+                const action = actions.getBy(getPreviewId(i));
+                if (!action) {
+                    break;
+                }
+                previewActions.push(action);
             }
+            previewActions.forEach(previewAction => {
+                previewAction.state.disabled = !config.isPreviewEnabled;
+            })
+
+            const authoringAction = actions.getBy('item-authoring');
             if(authoringAction){
                 authoringAction.state.disabled = !config.isAuthoringEnabled;
             }


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1695

### Summary

Add the possibility of having more than one item previewer.

### Details

It supports multiple preview buttons from the item's property page.

This is made thanks to a configuration applied in `config/tao/client_lib_config_registry.conf.php`, and a change applied to the `structures.xml` file.

- **structures.xml**
Each button must be declared with an identifier starting with `item-preview`. The first button must be `item-preview`, the second `item-preview-1`, etc. The suffix number refers to a position in the configuration (see `client_lib_config_registry.conf.php`).
Example:
```xml
    <structure id="items" name="Items" level="0" group="main">
        <sections>
            <section id="manage_items" name="Manage items" url="/taoItems/Items/index">
                <actions>
                    <action id="item-preview" name="Preview" url="/taoItems/ItemPreview/index" context="instance" group="content" binding="itemPreview">
                        <icon id="icon-preview"/>
                    </action>
                    <action id="item-preview-1" name="Preview (legacy)" url="/taoItems/ItemPreview/index" context="instance" group="content" binding="itemPreview">
                        <icon id="icon-preview"/>
                    </action>
                </actions>
            </section>
        </sections>
    </structure>
```

- **client_lib_config_registry.conf.php**
The configuration can be extended with a list of possible providers, aside from the default one. This is done in `config/tao/client_lib_config_registry.conf.php`.
Example:
```php
        'taoItems/controller/items/action' => array(
            'provider' => 'qtiItemNUI',
            'providers' => array(
                array(
                    'id' => 'qtiItemNUI',
                    'label' => 'Preview'
                ),
                array(
                    'id' => 'qtiItem',
                    'label' => 'Preview (legacy)'
                )
            )
        ),
```

### How to test

- checkout the branch: `git checkout -t origin/feature/ADF-1695/multiple-preview-buttons`
- also checkout the branches from the companion PR
- make sure to have set the appropriate configuration (check the details in the ticket)