### PR TITLE
Feature/ADF-1782/Implement the UI for the list of translations

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -73,7 +73,7 @@
                         <icon id="icon-move-item"/>
                     </action>
                     <action id="item-translate" name="Translate" url="/tao/Translation/translate" context="instance" group="tree" binding="translateItem">
-                        <icon id="icon-spell-check"/>
+                        <icon id="icon-replace"/>
                     </action>
                 </actions>
             </section>

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -21,6 +21,7 @@ define([
     'jquery',
     'i18n',
     'module',
+    'layout/actions',
     'layout/actions/binder',
     'layout/section',
     'form/translation',
@@ -43,6 +44,7 @@ define([
     $,
     __,
     module,
+    actionManager,
     binder,
     section,
     translationFormFactory,
@@ -70,8 +72,16 @@ define([
         const { rootClassUri, id: resourceUri } = actionContext;
         translationFormFactory($container, { rootClassUri, resourceUri })
             .on('edit', (translationUri, languageUri) => {
-                // TODO: replace this by the redirection to the editor
-                setTimeout(() => alert(`Editing translation for ${languageUri}: ${translationUri}`), 250);
+                const editContext = {
+                    id: translationUri,
+                    resourceUri: translationUri,
+                    originResourceUri: resourceUri,
+                    rootClassUri,
+                    languageUri
+                };
+                // TODO: finalize the redirection to the editor
+                console.log('editContext', editContext);
+                actionManager.exec('item-authoring', editContext);
             })
             .on('error', error => {
                 logger.error(error);

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -22,7 +22,10 @@ define([
     'i18n',
     'module',
     'layout/actions/binder',
+    'layout/section',
+    'form/translation',
     'taoItems/previewer/factory',
+    'core/logger',
     'core/request',
     'ui/feedback',
     'ui/dialog/confirm',
@@ -41,7 +44,10 @@ define([
     __,
     module,
     binder,
+    section,
+    translationFormFactory,
     previewerFactory,
+    loggerFactory,
     request,
     feedback,
     confirmDialog,
@@ -55,6 +61,23 @@ define([
     forbiddenClassActionTpl
 ) {
     'use strict';
+
+    const logger = loggerFactory('taoItems/actions');
+
+    binder.register('translateItem', function (actionContext) {
+        section.current().updateContentBlock('<div class="main-container flex-container-full"></div>');
+        const $container = $('.main-container', section.selected.panel);
+        const { rootClassUri, id: resourceUri } = actionContext;
+        translationFormFactory($container, { rootClassUri, resourceUri })
+            .on('edit', (translationUri, languageUri) => {
+                // TODO: replace this by the redirection to the editor
+                setTimeout(() => alert(`Editing translation for ${languageUri}: ${translationUri}`), 250);
+            })
+            .on('error', error => {
+                logger.error(error);
+                feedback().error(__('An error occurred while processing your request.'));
+            });
+    });
 
     binder.register('itemPreview', function itemPreview(actionContext) {
         const defaultConfig = {


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1782

Requires: 
 - [x] https://github.com/oat-sa/tao-core/pull/4101

Also require `extension-tao-tests` and `extension-tao-itemqti` to be with the branch `feat/HKD-6/integration`

### Summary

Implement a form component for managing the list of translations for a resource.

Also implement the API client to connect with the server.

### Details

A component is now present in `form/translation` and connection with API services is given via `services/translation`.

The component shows:
- a creation form to add a translation
- a list of existing translations

When the user create a translation, or click the edit button, an event is triggered to command the editing.

The action `translateItem` installs this component and initiates it.

![image](https://github.com/user-attachments/assets/f9ab7c90-56e6-45a5-aa7e-3461ccfbb0bb)


### How to test

- checkout the branch: `git checkout -t origin/feature/ADF-1782/translation-list-ui`
- make sure to also install the companion PR
- select an item and see the translate button
- click the translate button (note: you need the item to be ready for translation, otherwise, the component will only show a placeholder message)


The following feature flags will also be needed:
```
FEATURE_FLAG_TRANSLATION_ENABLED=true
FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER=true
FEATURE_FLAG_TRANSLATION_DEVELOPER_MODE=true
```