### PR TITLE
Feature/ADF-1784/Side by side authoring

### DIFF
--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -359,15 +359,13 @@ class taoItems_actions_Items extends tao_actions_SaSModule
                         LockManager::getImplementation()
                             ->setLock($item, $this->getSession()->getUser()->getIdentifier());
 
-                        // TODO: better implement the following parameters
-                        // --- start
+                        // Add support for the translation and the side-by-side authoring tool
                         if ($this->getRequestParameter('translation') !== null) {
-                            $authoringUrl .= '&translation=' . $this->getRequestParameter('translation');
+                            $authoringUrl = sprintf('%s&translation=%s', $authoringUrl, $this->getRequestParameter('translation'));
                         }
                         if ($this->getRequestParameter('originResourceUri') !== null) {
-                            $authoringUrl .= '&originResourceUri=' . $this->getRequestParameter('originResourceUri');
+                            $authoringUrl = sprintf('%s&originResourceUri=%s', $authoringUrl, $this->getRequestParameter('originResourceUri'));
                         }
-                        // --- end
 
                         return $this->forwardUrl($authoringUrl);
                     }

--- a/actions/class.Items.php
+++ b/actions/class.Items.php
@@ -359,6 +359,16 @@ class taoItems_actions_Items extends tao_actions_SaSModule
                         LockManager::getImplementation()
                             ->setLock($item, $this->getSession()->getUser()->getIdentifier());
 
+                        // TODO: better implement the following parameters
+                        // --- start
+                        if ($this->getRequestParameter('translation') !== null) {
+                            $authoringUrl .= '&translation=' . $this->getRequestParameter('translation');
+                        }
+                        if ($this->getRequestParameter('originResourceUri') !== null) {
+                            $authoringUrl .= '&originResourceUri=' . $this->getRequestParameter('originResourceUri');
+                        }
+                        // --- end
+
                         return $this->forwardUrl($authoringUrl);
                     }
                 }
@@ -372,7 +382,7 @@ class taoItems_actions_Items extends tao_actions_SaSModule
                 if (!empty($itemModel) && $itemModel instanceof core_kernel_classes_Resource) {
                     $errorMsg = __(
                         'No item authoring tool available for the selected type of item: %s'
-                        . $itemModel->getLabel()
+                            . $itemModel->getLabel()
                     );
                 } else {
                     $errorMsg = __('No item type selected for the current item.')

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -70,7 +70,7 @@ define([
         section.current().updateContentBlock('<div class="main-container flex-container-full"></div>');
         const $container = $('.main-container', section.selected.panel);
         const { rootClassUri, id: resourceUri } = actionContext;
-        translationFormFactory($container, { rootClassUri, resourceUri })
+        translationFormFactory($container, { rootClassUri, resourceUri, allowDeletion: true })
             .on('edit', (id, language) => {
                 return actionManager.exec('item-authoring', {
                     id,
@@ -80,6 +80,19 @@ define([
                     translation: true,
                     actionParams: ['originResourceUri', 'language', 'translation']
                 });
+            })
+            .on('delete', function onDelete(id, language) {
+                // TODO: fix the 500 error when deleting a translation
+                return actionManager
+                    .exec(
+                        'item-delete',
+                        Object.assign({}, actionContext, {
+                            id,
+                            language,
+                            uri: uri.encode(id)
+                        })
+                    )
+                    .then(() => this.updateList());
             })
             .on('error', error => {
                 logger.error(error);

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -72,12 +72,13 @@ define([
         const { rootClassUri, id: resourceUri } = actionContext;
         translationFormFactory($container, { rootClassUri, resourceUri })
             .on('edit', (id, language) => {
-                actionManager.exec('item-authoring', {
+                return actionManager.exec('item-authoring', {
                     id,
                     language,
                     rootClassUri,
-                    mode: 'dual',
-                    actionParams: ['language', 'mode']
+                    originResourceUri: resourceUri,
+                    translation: true,
+                    actionParams: ['originResourceUri', 'language', 'translation']
                 });
             })
             .on('error', error => {

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -71,17 +71,14 @@ define([
         const $container = $('.main-container', section.selected.panel);
         const { rootClassUri, id: resourceUri } = actionContext;
         translationFormFactory($container, { rootClassUri, resourceUri })
-            .on('edit', (translationUri, languageUri) => {
-                const editContext = {
-                    id: translationUri,
-                    resourceUri: translationUri,
-                    originResourceUri: resourceUri,
+            .on('edit', (id, language) => {
+                actionManager.exec('item-authoring', {
+                    id,
+                    language,
                     rootClassUri,
-                    languageUri
-                };
-                // TODO: finalize the redirection to the editor
-                console.log('editContext', editContext);
-                actionManager.exec('item-authoring', editContext);
+                    mode: 'dual',
+                    actionParams: ['language', 'mode']
+                });
             })
             .on('error', error => {
                 logger.error(error);

--- a/views/js/controller/items/action.js
+++ b/views/js/controller/items/action.js
@@ -25,6 +25,7 @@ define([
     'layout/actions/binder',
     'layout/section',
     'form/translation',
+    'services/translation',
     'taoItems/previewer/factory',
     'core/logger',
     'core/request',
@@ -48,6 +49,7 @@ define([
     binder,
     section,
     translationFormFactory,
+    translationService,
     previewerFactory,
     loggerFactory,
     request,
@@ -82,17 +84,10 @@ define([
                 });
             })
             .on('delete', function onDelete(id, language) {
-                // TODO: fix the 500 error when deleting a translation
-                return actionManager
-                    .exec(
-                        'item-delete',
-                        Object.assign({}, actionContext, {
-                            id,
-                            language,
-                            uri: uri.encode(id)
-                        })
-                    )
-                    .then(() => this.updateList());
+                return translationService.deleteTranslation(resourceUri, language).then(() => {
+                    feedback().success(__('Translation deleted'));
+                    return this.refresh();
+                });
             })
             .on('error', error => {
                 logger.error(error);


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1784

### Summary

Add the side-by-side UI in the item authoring when translating.

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/f90000dc-5fd4-4a21-bc57-9e7fdf874e73">

### Details

Add support for:
- delete a translation
- opening an item for translation

Note: the server side may need to be refactored as it is fast approach.

### How to test
- checkout the branch: `git checkout -t origin/feature/ADF-1784/side-by-side-authoring`
- also make sure to checkout the companion PRs
- make sure to have the Feature Flags activated
```
FEATURE_FLAG_TRANSLATION_ENABLED=true
FEATURE_FLAG_UNIQUE_NUMERIC_QTI_IDENTIFIER=true
FEATURE_FLAG_TRANSLATION_DEVELOPER_MODE=true
```
- make sure to have the Item Translator role assigned to your user
- have an item ready for translation and add/edit a translation: it should present the side-by-side authoring
- from a regular item, also open the authoring: it should present the usual authoring