### PR TITLE
fix: use copy-to icon for quickwins design

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -58,10 +58,10 @@
                         <icon id="icon-copy"/>
                     </action>
                     <action id="item-copy-to" name="Copy To" url="/taoItems/Items/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
-                        <icon id="icon-copy"/>
+                        <icon id="icon-copy" alt="icon-copy-to"/>
                     </action>
                     <action id="class-copy-to" name="Copy To" url="/taoItems/Items/copyClass" context="class" group="tree" binding="copyClassTo" weight="7">
-                        <icon id="icon-copy"/>
+                        <icon id="icon-copy" alt="icon-copy-to"/>
                     </action>
                     <action id="item-move-to" name="Move To" url="/taoItems/Items/moveResource" context="instance" group="tree" binding="moveTo" weight="6">
                         <icon id="icon-move-item"/>

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -55,13 +55,13 @@
                         <icon id="icon-export"/>
                     </action>
                     <action id="item-duplicate" name="Duplicate" url="/taoItems/Items/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="8">
-                        <icon id="icon-copy"/>
+                        <icon id="icon-duplicate"/>
                     </action>
                     <action id="item-copy-to" name="Copy To" url="/taoItems/Items/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
-                        <icon id="icon-copy" alt="icon-copy-to"/>
+                        <icon id="icon-copy"/>
                     </action>
                     <action id="class-copy-to" name="Copy To" url="/taoItems/Items/copyClass" context="class" group="tree" binding="copyClassTo" weight="7">
-                        <icon id="icon-copy" alt="icon-copy-to"/>
+                        <icon id="icon-copy"/>
                     </action>
                     <action id="item-move-to" name="Move To" url="/taoItems/Items/moveResource" context="instance" group="tree" binding="moveTo" weight="6">
                         <icon id="icon-move-item"/>


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4061

## What's Changed

- Added support of alternative icon, specifically alternative for the `Copy` icon

## How to test

- Run the app with FEATURE_FLAG_QUICK_WINS_ENABLED FF enabled
- Check Copy to icons are updated accordingly