### PR TITLE
Feat/inf 287/do not show not accessible item classes

### DIFF
--- a/models/classes/search/ItemClassListService.php
+++ b/models/classes/search/ItemClassListService.php
@@ -25,7 +25,6 @@ namespace oat\taoItems\model\search;
 use core_kernel_classes_Resource;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\data\permission\PermissionInterface;
-use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\generis\model\OntologyRdfs;
 use oat\oatbox\session\SessionService;
 use oat\tao\model\TaoOntology;
@@ -33,14 +32,12 @@ use oat\tao\model\TaoOntology;
 class ItemClassListService
 {
     private const CLASS_LIST_LIMIT = 10;
-    private ComplexSearchService $complexSearchService;
     private Ontology $ontology;
     private PermissionInterface $permissionManager;
     private SessionService $sessionService;
 
-    public function __construct(ComplexSearchService $complexSearchService, Ontology $ontology, PermissionInterface $permissionManager, $sessionService)
+    public function __construct(Ontology $ontology, PermissionInterface $permissionManager, $sessionService)
     {
-        $this->complexSearchService = $complexSearchService;
         $this->ontology = $ontology;
         $this->permissionManager = $permissionManager;
         $this->sessionService = $sessionService;

--- a/models/classes/search/ItemClassListService.php
+++ b/models/classes/search/ItemClassListService.php
@@ -31,7 +31,7 @@ use oat\tao\model\TaoOntology;
 
 class ItemClassListService
 {
-    private const CLASS_LIST_LIMIT = 10;
+    private const CLASS_LIST_LIMIT = 25;
     private Ontology $ontology;
     private PermissionInterface $permissionManager;
     private SessionService $sessionService;
@@ -62,9 +62,9 @@ class ItemClassListService
             $this->getDynamicQueryParameters($page, $basicQueryParameters)
         );
 
-        $skipped = $this->skipNotAccessible($searchResult);
+        $this->skipNotAccessible($searchResult);
 
-        $result['total'] = ($root->countInstances($query, $basicQueryParameters) - $skipped) ?? 0;
+        $result['total'] = $root->countInstances($query, $basicQueryParameters) ?? 0;
         $result['items'] = [];
 
         foreach ($searchResult as $row) {
@@ -103,11 +103,11 @@ class ItemClassListService
         );
     }
 
-    private function skipNotAccessible(array &$results): int
+    private function skipNotAccessible(array &$results): void
     {
         if (!count($this->permissionManager->getSupportedRights())) {
             // if DAC is not enabled
-            return 0;
+            return;
         }
 
         $uris = array_map(function (core_kernel_classes_Resource $a): string {
@@ -124,7 +124,5 @@ class ItemClassListService
                 $noAccessCount++;
             }
         }
-
-        return $noAccessCount;
     }
 }

--- a/models/classes/search/ItemClassListService.php
+++ b/models/classes/search/ItemClassListService.php
@@ -116,12 +116,10 @@ class ItemClassListService
 
         $permissions = $this->permissionManager->getPermissions($this->sessionService->getCurrentUser(), $uris);
 
-        $noAccessCount = 0;
         foreach ($results as $key => &$row) {
             $uri = $row->getUri();
             if (isset($permissions[$uri]) && !in_array(PermissionInterface::RIGHT_WRITE, $permissions[$uri])) {
                 unset($results[$key]);
-                $noAccessCount++;
             }
         }
     }

--- a/models/classes/search/ItemClassListService.php
+++ b/models/classes/search/ItemClassListService.php
@@ -105,13 +105,18 @@ class ItemClassListService
 
     private function skipNotAccessible(array &$results): int
     {
-        $noAccessCount = 0;
+        if (!count($this->permissionManager->getSupportedRights())) {
+            // if DAC is not enabled
+            return 0;
+        }
+
         $uris = array_map(function (core_kernel_classes_Resource $a): string {
             return $a->getUri();
         }, $results);
 
         $permissions = $this->permissionManager->getPermissions($this->sessionService->getCurrentUser(), $uris);
 
+        $noAccessCount = 0;
         foreach ($results as $key => &$row) {
             $uri = $row->getUri();
             if (isset($permissions[$uri]) && !in_array(PermissionInterface::RIGHT_WRITE, $permissions[$uri])) {

--- a/models/classes/search/ItemClassListServiceProvider.php
+++ b/models/classes/search/ItemClassListServiceProvider.php
@@ -25,7 +25,6 @@ namespace oat\taoItems\model\search;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\data\permission\PermissionInterface;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
-use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\oatbox\session\SessionService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -38,7 +37,6 @@ class ItemClassListServiceProvider implements ContainerServiceProviderInterface
         $services = $configurator->services();
         $services->set(ItemClassListService::class, ItemClassListService::class)
             ->args([
-                service(ComplexSearchService::SERVICE_ID),
                 service(Ontology::SERVICE_ID),
                 service(PermissionInterface::SERVICE_ID),
                 service(SessionService::SERVICE_ID),

--- a/models/classes/search/ItemClassListServiceProvider.php
+++ b/models/classes/search/ItemClassListServiceProvider.php
@@ -23,8 +23,10 @@ declare(strict_types=1);
 namespace oat\taoItems\model\search;
 
 use oat\generis\model\data\Ontology;
+use oat\generis\model\data\permission\PermissionInterface;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use oat\oatbox\session\SessionService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
@@ -38,6 +40,8 @@ class ItemClassListServiceProvider implements ContainerServiceProviderInterface
             ->args([
                 service(ComplexSearchService::SERVICE_ID),
                 service(Ontology::SERVICE_ID),
+                service(PermissionInterface::SERVICE_ID),
+                service(SessionService::SERVICE_ID),
             ])
             ->public();
     }

--- a/test/unit/models/classes/search/ItemClassListServiceTest.php
+++ b/test/unit/models/classes/search/ItemClassListServiceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\models\classes\search;
+
+use core_kernel_classes_Class;
+use oat\oatbox\user\User;
+use oat\taoItems\model\search\ItemClassListService;
+use oat\generis\model\data\Ontology;
+use oat\generis\model\data\permission\PermissionInterface;
+use oat\oatbox\session\SessionService;
+use PHPUnit\Framework\TestCase;
+
+class ItemClassListServiceTest extends TestCase
+{
+    private ItemClassListService $sut;
+    private Ontology $ontologyMock;
+    private PermissionInterface $permissionManagerMock;
+    private SessionService $sessionServiceMock;
+
+    protected function setUp(): void
+    {
+        $this->ontologyMock = $this->createMock(Ontology::class);
+        $this->permissionManagerMock = $this->createMock(PermissionInterface::class);
+        $this->sessionServiceMock = $this->createMock(SessionService::class);
+
+        $this->sut = new ItemClassListService(
+            $this->ontologyMock,
+            $this->permissionManagerMock,
+            $this->sessionServiceMock
+        );
+    }
+
+    public function testGetListHappyPath(): void
+    {
+        $query = 'test';
+        $page = '1';
+
+        $mockRootClass = $this->createMock(core_kernel_classes_Class::class);
+        $mockRootClass->method('getUri')->willReturn('test-uri');
+        $mockRootClass->method('getLabel')->willReturn('Test Label');
+        $mockRootClass->method('getParentClassesIds')->willReturn([]);
+
+        $this->ontologyMock->method('getClass')->willReturn($mockRootClass);
+        $this->permissionManagerMock->method('getSupportedRights')->willReturn([]);
+
+        $mockRootClass->method('searchInstances')->willReturn([$mockRootClass]);
+        $mockRootClass->method('countInstances')->willReturn(1);
+
+        $result = $this->sut->getList($query, $page);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('total', $result);
+        $this->assertArrayHasKey('items', $result);
+        $this->assertEquals(1, $result['total']);
+        $this->assertCount(1, $result['items']);
+        $this->assertEquals('test-uri', $result['items'][0]['id']);
+    }
+
+    public function testGetListFiltersOutInaccessibleItems()
+    {
+        $query = 'test';
+        $page = '1';
+
+        $accessibleClass = $this->createMock(core_kernel_classes_Class::class);
+        $accessibleClass->method('getUri')->willReturn('accessible-uri');
+        $accessibleClass->method('getLabel')->willReturn('Accessible Label');
+
+        $inaccessibleClass = $this->createMock(core_kernel_classes_Class::class);
+        $inaccessibleClass->method('getUri')->willReturn('inaccessible-uri');
+        $inaccessibleClass->method('getLabel')->willReturn('Inaccessible Label');
+
+        $this->ontologyMock->method('getClass')->willReturn($accessibleClass);
+        $this->sessionServiceMock->method('getCurrentUser')->willReturn(
+            $this->createMock(User::class)
+        );
+        $this->permissionManagerMock->method('getSupportedRights')->willReturn([
+            PermissionInterface::RIGHT_WRITE,
+            PermissionInterface::RIGHT_READ,
+        ]);
+        $this->permissionManagerMock->method('getPermissions')->willReturn([
+            'accessible-uri' => [PermissionInterface::RIGHT_WRITE],
+            'inaccessible-uri' => [PermissionInterface::RIGHT_READ]
+        ]);
+
+        $accessibleClass->method('searchInstances')->willReturn([$accessibleClass, $inaccessibleClass]);
+        $accessibleClass->method('countInstances')->willReturn(2);
+
+        $result = $this->sut->getList($query, $page);
+
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('total', $result);
+        $this->assertArrayHasKey('items', $result);
+        $this->assertEquals(2, $result['total']);
+        $this->assertCount(1, $result['items']);
+        $this->assertEquals('accessible-uri', $result['items'][0]['id']);
+    }
+}


### PR DESCRIPTION
When importing a test it is possible to select destination class where related items will be imported. However user was able to chose a class which they do not have access for.

What is done:
- restricted item classes filtered out of the list
- changes covered by unit test

How to test:
- Create a user
- Create classes with similar names
- Setup Access control to limit access for the user to some classes
- Login as the user
- Open test import form
- Select destination for import
- Ensure that restricted item classes do not appear in the list

https://github.com/user-attachments/assets/b4d350df-218e-4206-9961-993f6d70baab

