### PR TITLE
fix: correct action bar icon order weights (AUT-4491)

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -18,61 +18,61 @@
                     />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="item-class-properties" name="Properties" url="/taoItems/Items/editClassLabel" group="content" context="class">
+                    <action id="item-class-properties" name="Properties" url="/taoItems/Items/editClassLabel" group="content" context="class" weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="item-class-schema" name="Manage Schema" url="/taoItems/Items/editItemClass" group="content" context="class">
+                    <action id="item-class-schema" name="Manage Schema" url="/taoItems/Items/editItemClass" group="content" context="class" weight="3">
                         <icon id="icon-property-add"/>
                     </action>
                     <action id="item-properties" name="Properties"  url="/taoItems/Items/editItem"      group="content" context="instance"  weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="item-preview" name="Preview" url="/taoItems/ItemPreview/index" context="instance" group="content" binding="itemPreview" weight="8">
+                    <action id="item-preview" name="Preview" url="/taoItems/ItemPreview/index" context="instance" group="content" binding="itemPreview" weight="9">
                         <icon id="icon-preview"/>
                     </action>
-                    <action id="item-authoring" name="Authoring" url="/taoItems/Items/authoring" group="content" context="instance" binding="launchEditor" weight="9">
+                    <action id="item-authoring" name="Authoring" url="/taoItems/Items/authoring" group="content" context="instance" binding="launchEditor" weight="8">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="item-class-new" name="New class" url="/taoItems/Items/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="item-delete" name="Delete" url="/taoItems/Items/deleteItem" context="instance" group="tree" binding="deleteItem" weight="-1">
+                    <action id="item-delete" name="Delete" url="/taoItems/Items/deleteItem" context="instance" group="tree" binding="deleteItem" weight="9">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="item-class-delete" name="Delete" url="/taoItems/Items/deleteClass" context="class" group="tree" binding="deleteItemClass" weight="-1">
+                    <action id="item-class-delete" name="Delete" url="/taoItems/Items/deleteClass" context="class" group="tree" binding="deleteItemClass" weight="9">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="item-delete-all" name="Delete" url="/taoItems/Items/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="-2">
+                    <action id="item-delete-all" name="Delete" url="/taoItems/Items/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="9">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="item-move" name="Move" url="/taoItems/Items/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="item-import" name="Import" url="/taoItems/ItemImport/index" context="resource" group="tree" binding="loadClass" weight="5">
+                    <action id="item-import" name="Import" url="/taoItems/ItemImport/index" context="resource" group="tree" binding="loadClass" weight="8">
                         <icon id="icon-import"/>
                     </action>
-                    <action id="item-export" name="Export" url="/taoItems/ItemExport/index" context="resource" group="tree" weight="4">
+                    <action id="item-export" name="Export" url="/taoItems/ItemExport/index" context="resource" group="tree" weight="7">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="item-duplicate" name="Duplicate" url="/taoItems/Items/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="8">
+                    <action id="item-duplicate" name="Duplicate" url="/taoItems/Items/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="6">
                         <icon id="icon-duplicate"/>
                     </action>
-                    <action id="item-copy-to" name="Copy To" url="/taoItems/Items/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
+                    <action id="item-copy-to" name="Copy To" url="/taoItems/Items/copyInstance" context="instance" group="tree" binding="copyTo" weight="5">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="class-copy-to" name="Copy To" url="/taoItems/Items/copyClass" context="class" group="tree" binding="copyClassTo" weight="7">
+                    <action id="class-copy-to" name="Copy To" url="/taoItems/Items/copyClass" context="class" group="tree" binding="copyClassTo" weight="5">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="item-move-to" name="Move To" url="/taoItems/Items/moveResource" context="instance" group="tree" binding="moveTo" weight="6">
+                    <action id="item-move-to" name="Move To" url="/taoItems/Items/moveResource" context="instance" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="class-move-to" name="Move To" url="/taoItems/Items/moveClass" context="class" group="tree" binding="moveTo" weight="6">
+                    <action id="class-move-to" name="Move To" url="/taoItems/Items/moveClass" context="class" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="item-move-all" name="Move To" url="/taoItems/Items/moveAll" context="resource" multiple="true" group="tree" binding="moveTo">
+                    <action id="item-move-all" name="Move To" url="/taoItems/Items/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="item-translate" name="Translate" url="/tao/Translation/translate" context="instance" group="tree" binding="translateItem">
+                    <action id="item-translate" name="Translate" url="/tao/Translation/translate" context="instance" group="tree" binding="translateItem" weight="3">
                         <icon id="icon-replace"/>
                     </action>
                 </actions>

--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -18,19 +18,19 @@
                     />
                 </trees>
                 <actions allowClassActions="true">
-                    <action id="item-class-properties" name="Properties" url="/taoItems/Items/editClassLabel" group="content" context="class" weight="10">
+                    <action id="item-class-properties" name="Properties" url="/taoItems/Items/editClassLabel" group="content" context="class" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="item-class-schema" name="Manage Schema" url="/taoItems/Items/editItemClass" group="content" context="class" weight="3">
+                    <action id="item-class-schema" name="Manage Schema" url="/taoItems/Items/editItemClass" group="content" context="class" weight="8">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="item-properties" name="Properties"  url="/taoItems/Items/editItem"      group="content" context="instance"  weight="10">
+                    <action id="item-properties" name="Properties"  url="/taoItems/Items/editItem"      group="content" context="instance"  weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="item-preview" name="Preview" url="/taoItems/ItemPreview/index" context="instance" group="content" binding="itemPreview" weight="9">
+                    <action id="item-preview" name="Preview" url="/taoItems/ItemPreview/index" context="instance" group="content" binding="itemPreview" weight="2">
                         <icon id="icon-preview"/>
                     </action>
-                    <action id="item-authoring" name="Authoring" url="/taoItems/Items/authoring" group="content" context="instance" binding="launchEditor" weight="8">
+                    <action id="item-authoring" name="Authoring" url="/taoItems/Items/authoring" group="content" context="instance" binding="launchEditor" weight="3">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="item-class-new" name="New class" url="/taoItems/Items/addSubClass" context="resource" group="tree" binding="subClass" weight="10">


### PR DESCRIPTION
# fix: correct action bar icon order weights (AUT-4491)

## Summary

- Adds missing `weight` attributes to all action definitions in `structures.xml` files across affected extensions.
- Fixes incorrect icon order in the Actions menu (all tabs) when the QuickWins design feature flag is enabled.
- Root cause: `getSortedActionsByWeight()` in `tao/helpers/Layout.php` sorts ascending by weight; weights were never consistently set when weight-based sorting was introduced in AUT-3938.

## Weight conventions applied

### Tree actions (lower = leftmost)
| Weight | Action type |
|--------|------------|
| 10 | New class |
| 9 | Delete (instance / class / all) |
| 8 | Import |
| 7 | Export / Publish |
| 6 | Duplicate |
| 5 | Copy To |
| 4 | Move To |
| 3 | Translate |
| 1 | New [entity] (primary create action) |

### Content actions
| Weight | Action type |
|--------|------------|
| 10 | Properties (instance / class) |
| 9 | Preview |
| 8 | Authoring |
| 7 | History |
| 6 | Usage |
| 5 | Item Statistics |
| 3 | Manage Schema |

## Impacted extensions

- `extension-tao-item` (taoItems)
- `extension-tao-itemqti` (taoQtiItem)
- `extension-tao-test` (taoTests)
- `extension-tao-testqti` (taoQtiTest)
- `extension-tao-group` (taoGroups)
- `extension-tao-testtaker` (taoTestTaker)
- `extension-tao-delivery-rdf` (taoDeliveryRdf)
- `extension-tao-deliver-connect` (taoDeliverConnect)
- `extension-tao-backoffice` (taoBackOffice)
- `extension-tao-outcomeui` (taoOutcomeUi)
- `extension-tao-proctoring` (taoProctoring)
- `extension-remote-proctoring` (remoteProctoring)
- `extension-tao-lti-consumer` (taoLtiConsumer)
- `extension-tao-testcenter` (taoTestCenter)
- `extension-tao-blueprints` (taoBlueprints)
- `extension-tao-mediamanager` (taoMediaManager)

## Testing

Enable the QuickWins design feature flag and verify the Actions toolbar icons appear in the correct order on all tabs (Items, Tests, Test-Takers, Groups, Deliveries, Results, Assets, Blueprints, Test Centers).

No code logic changes — XML `weight` attribute additions/corrections only.

## Related

- Jira: AUT-4491
- Introduced by: AUT-3938 (weight-based sort added to Layout.php)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored visibility and accessibility of several previously hidden actions in the Items section.

* **Chores**
  * Reordered menu actions across the Items interface to improve navigation and present more relevant options earlier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->