### PR TITLE
Backport/AUT-4491/align items tree action weights

### DIFF
--- a/actions/structures.xml
+++ b/actions/structures.xml
@@ -33,46 +33,46 @@
                     <action id="item-authoring" name="Authoring" url="/taoItems/Items/authoring" group="content" context="instance" binding="launchEditor" weight="3">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="item-class-new" name="New class" url="/taoItems/Items/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
+                    <action id="item-class-new" name="New class" url="/taoItems/Items/addSubClass" context="resource" group="tree" binding="subClass" weight="1">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="item-delete" name="Delete" url="/taoItems/Items/deleteItem" context="instance" group="tree" binding="deleteItem" weight="9">
+                    <action id="item-delete" name="Delete" url="/taoItems/Items/deleteItem" context="instance" group="tree" binding="deleteItem" weight="2">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="item-class-delete" name="Delete" url="/taoItems/Items/deleteClass" context="class" group="tree" binding="deleteItemClass" weight="9">
+                    <action id="item-class-delete" name="Delete" url="/taoItems/Items/deleteClass" context="class" group="tree" binding="deleteItemClass" weight="3">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="item-delete-all" name="Delete" url="/taoItems/Items/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="9">
+                    <action id="item-delete-all" name="Delete" url="/taoItems/Items/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="4">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="item-move" name="Move" url="/taoItems/Items/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="item-import" name="Import" url="/taoItems/ItemImport/index" context="resource" group="tree" binding="loadClass" weight="8">
+                    <action id="item-import" name="Import" url="/taoItems/ItemImport/index" context="resource" group="tree" binding="loadClass" weight="5">
                         <icon id="icon-import"/>
                     </action>
-                    <action id="item-export" name="Export" url="/taoItems/ItemExport/index" context="resource" group="tree" weight="7">
+                    <action id="item-export" name="Export" url="/taoItems/ItemExport/index" context="resource" group="tree" weight="6">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="item-duplicate" name="Duplicate" url="/taoItems/Items/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="6">
+                    <action id="item-duplicate" name="Duplicate" url="/taoItems/Items/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="7">
                         <icon id="icon-duplicate"/>
                     </action>
-                    <action id="item-copy-to" name="Copy To" url="/taoItems/Items/copyInstance" context="instance" group="tree" binding="copyTo" weight="5">
+                    <action id="item-copy-to" name="Copy To" url="/taoItems/Items/copyInstance" context="instance" group="tree" binding="copyTo" weight="8">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="class-copy-to" name="Copy To" url="/taoItems/Items/copyClass" context="class" group="tree" binding="copyClassTo" weight="5">
+                    <action id="class-copy-to" name="Copy To" url="/taoItems/Items/copyClass" context="class" group="tree" binding="copyClassTo" weight="9">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="item-move-to" name="Move To" url="/taoItems/Items/moveResource" context="instance" group="tree" binding="moveTo" weight="4">
+                    <action id="item-move-to" name="Move To" url="/taoItems/Items/moveResource" context="instance" group="tree" binding="moveTo" weight="10">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="class-move-to" name="Move To" url="/taoItems/Items/moveClass" context="class" group="tree" binding="moveTo" weight="4">
+                    <action id="class-move-to" name="Move To" url="/taoItems/Items/moveClass" context="class" group="tree" binding="moveTo" weight="11">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="item-move-all" name="Move To" url="/taoItems/Items/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="4">
+                    <action id="item-move-all" name="Move To" url="/taoItems/Items/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="12">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="item-translate" name="Translate" url="/tao/Translation/translate" context="instance" group="tree" binding="translateItem" weight="3">
+                    <action id="item-translate" name="Translate" url="/tao/Translation/translate" context="instance" group="tree" binding="translateItem" weight="13">
                         <icon id="icon-replace"/>
                     </action>
                 </actions>


### PR DESCRIPTION
## Summary
- backport AUT-4491 items tree action weight alignment from `v13.1.5` to `v13.1.2.1`

## Source
- release: https://github.com/oat-sa/extension-tao-item/releases/tag/v13.1.5
- PR: https://github.com/oat-sa/extension-tao-item/pull/739
- cherry-picked commit: `e20440504bb0bbab87674f39a17ff6bd228898ea`

## Scope
- `actions/structures.xml`

## Notes
- `v13.1.3` and `v13.1.4` changes are intentionally excluded
- only AUT-4491 ordering fix is included in this backport
