### PR TITLE
[OCE-216] Fix: add FF coverage for manage_items functionality

### DIFF
--- a/migrations/Version202606101250452141_taoItems.php
+++ b/migrations/Version202606101250452141_taoItems.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoItems\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoItems\scripts\install\SetupSectionVisibilityFilters;
+
+/**
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202606101250452141_taoItems extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Hide Usage and Item Statistics actions when FEATURE_FLAG_HIDE_MANAGE_ITEMS is enabled';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $script = new SetupSectionVisibilityFilters();
+        $script->setServiceLocator($this->getServiceLocator());
+        $script([]);
+
+        $this->addReport(
+            Report::createSuccess(
+                'Usage and Item Statistics actions are hidden when FEATURE_FLAG_HIDE_MANAGE_ITEMS is enabled'
+            )
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentionally left empty: feature flag paths are merged into runtime config.
+    }
+}

--- a/scripts/install/SetupSectionVisibilityFilters.php
+++ b/scripts/install/SetupSectionVisibilityFilters.php
@@ -27,19 +27,36 @@ use oat\tao\model\menu\SectionVisibilityFilter;
 
 class SetupSectionVisibilityFilters extends InstallAction
 {
-    public function __invoke($params)
+    private const FEATURE_FLAG_TRANSLATION = 'FEATURE_FLAG_TRANSLATION_ENABLED';
+    private const FEATURE_FLAG_HIDE_MANAGE_ITEMS = 'FEATURE_FLAG_HIDE_MANAGE_ITEMS';
+
+    public function __invoke($params): void
     {
         /** @var SectionVisibilityFilter $sectionVisibilityFilter */
         $sectionVisibilityFilter = $this->getServiceManager()->get(SectionVisibilityFilter::SERVICE_ID);
+
         $sectionVisibilityFilter->showSectionByFeatureFlag(
             $sectionVisibilityFilter->createSectionPath(
                 [
                     'manage_items',
-                    'item-translate'
+                    'item-translate',
                 ]
             ),
-            'FEATURE_FLAG_TRANSLATION_ENABLED'
+            self::FEATURE_FLAG_TRANSLATION
         );
+
+        foreach (['item-usage', 'item-statistics'] as $actionId) {
+            $sectionVisibilityFilter->hideSectionByFeatureFlag(
+                $sectionVisibilityFilter->createSectionPath(
+                    [
+                        'manage_items',
+                        $actionId,
+                    ]
+                ),
+                self::FEATURE_FLAG_HIDE_MANAGE_ITEMS
+            );
+        }
+
         $this->getServiceManager()->register(SectionVisibilityFilter::SERVICE_ID, $sectionVisibilityFilter);
     }
 }


### PR DESCRIPTION
## Ticket: https://oat-sa.atlassian.net/browse/OCE-216

## What's Changed
- New feature-flag FEATURE_FLAG_HIDE_MANAGE_ITEMS for disable item Usage and Statistics actions

FEATURE_FLAG_HIDE_MANAGE_ITEMS - on

<img width="1840" height="972" alt="chrome_e9moJOlz8O" src="https://github.com/user-attachments/assets/0dbeeffa-c564-4310-9dcb-4991627ff41e" />

FEATURE_FLAG_HIDE_MANAGE_ITEMS - off

<img width="1840" height="972" alt="chrome_kWzVCXZDdf" src="https://github.com/user-attachments/assets/25e4579c-00e7-4e60-91a2-709f185b30f9" />


> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## Dependencies PRs
- https://github.com/oat-sa/..

## How to test
- Explain here how to test or make a small demo to our team how this works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Usage" and "Item Statistics" sections can be hidden via a runtime feature flag.
  * Translation-related item section visibility is now controllable via a feature flag.

* **Chores**
  * Added feature-flag driven controls to toggle visibility of item management sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->