### PR TITLE
feat: item comments API with RDF persistence proxy (NYSED-19)

### DIFF
--- a/actions/class.RestItemComments.php
+++ b/actions/class.RestItemComments.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+use oat\tao\model\http\HttpJsonResponseTrait;
+use oat\taoItems\model\Comment\ItemCommentService;
+
+/**
+ * Item comments REST API (FR1 M1).
+ *
+ * Routes:
+ * - GET  /taoItems/RestItemComments/index?itemUri=
+ * - POST /taoItems/RestItemComments/index  (itemUri, body)
+ * - GET  /taoItems/RestItemComments/count?itemUri=
+ */
+class taoItems_actions_RestItemComments extends tao_actions_CommonModule
+{
+    use HttpJsonResponseTrait;
+
+    public function index(): void
+    {
+        try {
+            if ($this->isGetRequest()) {
+                $itemUri = (string) ($this->getPsrRequest()->getQueryParams()['itemUri'] ?? '');
+                $this->setSuccessJsonResponse($this->getItemCommentService()->list($itemUri));
+
+                return;
+            }
+
+            if ($this->isPostRequest()) {
+                $payload = $this->getRequestPayload();
+                $itemUri = (string) ($payload['itemUri'] ?? '');
+                $body = (string) ($payload['body'] ?? '');
+                $comment = $this->getItemCommentService()->create($itemUri, $body);
+                $this->setSuccessJsonResponse($comment->toArray(), 201);
+
+                return;
+            }
+
+            $this->setErrorJsonResponse('Method not allowed', 405, [], 405);
+        } catch (common_exception_Unauthorized $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 403, [], 403);
+        } catch (InvalidArgumentException $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 412, [], 412);
+        } catch (Throwable $exception) {
+            $this->logError($exception->getMessage());
+            $this->setErrorJsonResponse('Unable to process item comments request', 500, [], 500);
+        }
+    }
+
+    public function count(): void
+    {
+        try {
+            if (!$this->isGetRequest()) {
+                $this->setErrorJsonResponse('Method not allowed', 405, [], 405);
+
+                return;
+            }
+
+            $itemUri = (string) ($this->getPsrRequest()->getQueryParams()['itemUri'] ?? '');
+            $this->setSuccessJsonResponse([
+                'count' => $this->getItemCommentService()->count($itemUri),
+            ]);
+        } catch (common_exception_Unauthorized $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 403, [], 403);
+        } catch (InvalidArgumentException $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 412, [], 412);
+        } catch (Throwable $exception) {
+            $this->logError($exception->getMessage());
+            $this->setErrorJsonResponse('Unable to process item comments count', 500, [], 500);
+        }
+    }
+
+    private function getRequestPayload(): array
+    {
+        $parsed = $this->getPsrRequest()->getParsedBody();
+        if (is_array($parsed) && $parsed !== []) {
+            return $parsed;
+        }
+
+        $raw = (string) $this->getPsrRequest()->getBody();
+        if ($raw === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function isGetRequest(): bool
+    {
+        return strtoupper($this->getPsrRequest()->getMethod()) === 'GET';
+    }
+
+    private function isPostRequest(): bool
+    {
+        return strtoupper($this->getPsrRequest()->getMethod()) === 'POST';
+    }
+
+    private function getItemCommentService(): ItemCommentService
+    {
+        return $this->getServiceLocator()->get(ItemCommentService::SERVICE_ID);
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -32,6 +32,7 @@ use oat\taoItems\model\Translation\ServiceProvider\TranslationServiceProvider;
 use oat\taoItems\model\user\TaoItemsRoles;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\taoItems\model\FrontendAction\FrontendActionServiceProvider;
+use oat\taoItems\model\Comment\ServiceProvider\ItemCommentServiceProvider;
 use oat\taoItems\scripts\install\RegisterNpmPaths;
 use oat\taoItems\model\Copier\CopierServiceProvider;
 use oat\taoItems\scripts\install\CreateItemDirectory;
@@ -39,6 +40,7 @@ use oat\taoItems\scripts\install\SetRolesPermissions;
 use oat\taoItems\scripts\install\RegisterCategoryService;
 use oat\taoItems\scripts\install\RegisterAssetTreeBuilder;
 use oat\taoItems\scripts\install\RegisterItemPreviewerRegistryService;
+use oat\taoItems\scripts\install\RegisterItemCommentServices;
 use oat\taoItems\scripts\install\SetupEventListeners;
 use oat\taoItems\scripts\install\SetupSectionVisibilityFilters;
 
@@ -63,6 +65,7 @@ return [
             __DIR__ . '/models/ontology/taoItemRunner.rdf',
             __DIR__ . '/models/ontology/indexation.rdf',
             __DIR__ . '/models/ontology/category.rdf',
+            __DIR__ . '/models/ontology/itemComment.rdf',
         ],
         'php' => [
             CreateItemDirectory::class,
@@ -72,7 +75,8 @@ return [
             RegisterAssetTreeBuilder::class,
             SetRolesPermissions::class,
             SetupEventListeners::class,
-            SetupSectionVisibilityFilters::class
+            SetupSectionVisibilityFilters::class,
+            RegisterItemCommentServices::class,
         ],
     ],
     'update' => taoItems_scripts_update_Updater::class,
@@ -87,6 +91,11 @@ return [
             AccessRule::GRANT,
             TaoItemsRoles::ITEM_AUTHOR_ABSTRACT,
             'taoItems_actions_ItemContent',
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_AUTHOR_ABSTRACT,
+            'taoItems_actions_RestItemComments',
         ],
         [
             AccessRule::GRANT,
@@ -272,5 +281,6 @@ return [
         TranslationServiceProvider::class,
         FormServiceProvider::class,
         FrontendActionServiceProvider::class,
+        ItemCommentServiceProvider::class,
     ],
 ];

--- a/migrations/Version202608031745002141_taoItems.php
+++ b/migrations/Version202608031745002141_taoItems.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoItems\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\taoItems\scripts\install\RegisterItemCommentServices;
+
+/**
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202608031745002141_taoItems extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register Item Comments RDF ontology and persistence services (NYSED-19)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+
+        $script = new RegisterItemCommentServices();
+        $script->setServiceLocator($this->getServiceLocator());
+        $script([]);
+
+        $this->addReport(Report::createSuccess('Item Comment services registered with RDF default adapter'));
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentionally left empty: ontology and services remain for forward compatibility.
+    }
+}

--- a/models/classes/Comment/ItemComment.php
+++ b/models/classes/Comment/ItemComment.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+final class ItemComment
+{
+    public const STATUS_ACTIVE = 'active';
+
+    private string $id;
+    private string $itemUri;
+    private string $authorId;
+    private string $authorLabel;
+    private string $body;
+    private string $createdAt;
+    private string $status;
+
+    public function __construct(
+        string $id,
+        string $itemUri,
+        string $authorId,
+        string $authorLabel,
+        string $body,
+        string $createdAt,
+        string $status = self::STATUS_ACTIVE
+    ) {
+        $this->id = $id;
+        $this->itemUri = $itemUri;
+        $this->authorId = $authorId;
+        $this->authorLabel = $authorLabel;
+        $this->body = $body;
+        $this->createdAt = $createdAt;
+        $this->status = $status;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getItemUri(): string
+    {
+        return $this->itemUri;
+    }
+
+    public function getAuthorId(): string
+    {
+        return $this->authorId;
+    }
+
+    public function getAuthorLabel(): string
+    {
+        return $this->authorLabel;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'itemUri' => $this->itemUri,
+            'authorId' => $this->authorId,
+            'authorLabel' => $this->authorLabel,
+            'body' => $this->body,
+            'createdAt' => $this->createdAt,
+            'status' => $this->status,
+        ];
+    }
+}

--- a/models/classes/Comment/ItemCommentOntology.php
+++ b/models/classes/Comment/ItemCommentOntology.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+final class ItemCommentOntology
+{
+    public const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment';
+    public const PROPERTY_ITEM_URI = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentItemUri';
+    public const PROPERTY_AUTHOR_ID = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentAuthorId';
+    public const PROPERTY_AUTHOR_LABEL = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentAuthorLabel';
+    public const PROPERTY_BODY = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentBody';
+    public const PROPERTY_CREATED_AT = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentCreatedAt';
+    public const PROPERTY_STATUS = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentStatus';
+}

--- a/models/classes/Comment/ItemCommentPersistenceInterface.php
+++ b/models/classes/Comment/ItemCommentPersistenceInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+interface ItemCommentPersistenceInterface
+{
+    public function create(ItemComment $comment): ItemComment;
+
+    /**
+     * @return ItemComment[]
+     */
+    public function findByItemUri(string $itemUri): array;
+
+    public function countByItemUri(string $itemUri): int;
+}

--- a/models/classes/Comment/ItemCommentPersistenceProxy.php
+++ b/models/classes/Comment/ItemCommentPersistenceProxy.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+use oat\oatbox\service\ConfigurableService;
+
+/**
+ * Delegates to the active adapter (RDF by default; Elasticsearch when AS replaces it).
+ */
+class ItemCommentPersistenceProxy extends ConfigurableService implements ItemCommentPersistenceInterface
+{
+    public const SERVICE_ID = 'taoItems/ItemCommentPersistence';
+    public const OPTION_ACTIVE_ADAPTER = 'activeAdapter';
+
+    public function create(ItemComment $comment): ItemComment
+    {
+        return $this->getActiveAdapter()->create($comment);
+    }
+
+    public function findByItemUri(string $itemUri): array
+    {
+        return $this->getActiveAdapter()->findByItemUri($itemUri);
+    }
+
+    public function countByItemUri(string $itemUri): int
+    {
+        return $this->getActiveAdapter()->countByItemUri($itemUri);
+    }
+
+    private function getActiveAdapter(): ItemCommentPersistenceInterface
+    {
+        $adapterId = $this->getOption(
+            self::OPTION_ACTIVE_ADAPTER,
+            RdfItemCommentAdapter::SERVICE_ID
+        );
+
+        /** @var ItemCommentPersistenceInterface $adapter */
+        $adapter = $this->getServiceLocator()->get($adapterId);
+
+        return $adapter;
+    }
+}

--- a/models/classes/Comment/ItemCommentService.php
+++ b/models/classes/Comment/ItemCommentService.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+use common_exception_Unauthorized;
+use common_session_SessionManager;
+use DateTimeImmutable;
+use DateTimeZone;
+use InvalidArgumentException;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use Ramsey\Uuid\Uuid;
+
+class ItemCommentService extends ConfigurableService
+{
+    public const SERVICE_ID = 'taoItems/ItemCommentService';
+
+    /**
+     * @return array{comments: array<int, array<string, string>>, count: int}
+     */
+    public function list(string $itemUri): array
+    {
+        $this->assertFeatureEnabled();
+        $itemUri = $this->assertItemUri($itemUri);
+
+        $comments = $this->getPersistence()->findByItemUri($itemUri);
+
+        return [
+            'comments' => array_map(
+                static function (ItemComment $comment): array {
+                    return $comment->toArray();
+                },
+                $comments
+            ),
+            'count' => count($comments),
+        ];
+    }
+
+    public function count(string $itemUri): int
+    {
+        $this->assertFeatureEnabled();
+        $itemUri = $this->assertItemUri($itemUri);
+
+        return $this->getPersistence()->countByItemUri($itemUri);
+    }
+
+    public function create(string $itemUri, string $body): ItemComment
+    {
+        $this->assertFeatureEnabled();
+        $itemUri = $this->assertItemUri($itemUri);
+        $body = $this->assertBody($body);
+
+        $session = common_session_SessionManager::getSession();
+        if ($session === null || $session->getUser() === null) {
+            throw new common_exception_Unauthorized('Authenticated session required to create item comments');
+        }
+
+        $comment = new ItemComment(
+            Uuid::uuid4()->toString(),
+            $itemUri,
+            (string) $session->getUser()->getIdentifier(),
+            (string) $session->getUserLabel(),
+            $body,
+            (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format(DATE_ATOM),
+            ItemComment::STATUS_ACTIVE
+        );
+
+        return $this->getPersistence()->create($comment);
+    }
+
+    private function getPersistence(): ItemCommentPersistenceInterface
+    {
+        return $this->getServiceLocator()->get(ItemCommentPersistenceProxy::SERVICE_ID);
+    }
+
+    private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
+    {
+        return $this->getServiceLocator()->get(FeatureFlagChecker::class);
+    }
+
+    private function assertFeatureEnabled(): void
+    {
+        if (
+            !$this->getFeatureFlagChecker()->isEnabled(
+                FeatureFlagCheckerInterface::FEATURE_FLAG_ITEM_COMMENTS_ENABLED
+            )
+        ) {
+            throw new common_exception_Unauthorized('Item comments feature is disabled');
+        }
+    }
+
+    private function assertItemUri(string $itemUri): string
+    {
+        $itemUri = trim($itemUri);
+        if ($itemUri === '') {
+            throw new InvalidArgumentException('itemUri is required');
+        }
+
+        return $itemUri;
+    }
+
+    private function assertBody(string $body): string
+    {
+        $body = trim($body);
+        if ($body === '') {
+            throw new InvalidArgumentException('Comment body must not be empty');
+        }
+
+        return $body;
+    }
+}

--- a/models/classes/Comment/RdfItemCommentAdapter.php
+++ b/models/classes/Comment/RdfItemCommentAdapter.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+use core_kernel_classes_Resource;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+
+class RdfItemCommentAdapter extends ConfigurableService implements ItemCommentPersistenceInterface
+{
+    use OntologyAwareTrait;
+
+    public const SERVICE_ID = 'taoItems/RdfItemCommentAdapter';
+
+    public function create(ItemComment $comment): ItemComment
+    {
+        $resource = $this->getClass(ItemCommentOntology::CLASS_URI)->createInstanceWithProperties([
+            ItemCommentOntology::PROPERTY_ITEM_URI => $comment->getItemUri(),
+            ItemCommentOntology::PROPERTY_AUTHOR_ID => $comment->getAuthorId(),
+            ItemCommentOntology::PROPERTY_AUTHOR_LABEL => $comment->getAuthorLabel(),
+            ItemCommentOntology::PROPERTY_BODY => $comment->getBody(),
+            ItemCommentOntology::PROPERTY_CREATED_AT => $comment->getCreatedAt(),
+            ItemCommentOntology::PROPERTY_STATUS => $comment->getStatus(),
+        ]);
+
+        return new ItemComment(
+            $resource->getUri(),
+            $comment->getItemUri(),
+            $comment->getAuthorId(),
+            $comment->getAuthorLabel(),
+            $comment->getBody(),
+            $comment->getCreatedAt(),
+            $comment->getStatus()
+        );
+    }
+
+    public function findByItemUri(string $itemUri): array
+    {
+        $resources = $this->getClass(ItemCommentOntology::CLASS_URI)->searchInstances(
+            [
+                ItemCommentOntology::PROPERTY_ITEM_URI => $itemUri,
+            ],
+            [
+                'recursive' => false,
+                'like' => false,
+            ]
+        );
+
+        $comments = [];
+        foreach ($resources as $resource) {
+            $comments[] = $this->mapResource($resource);
+        }
+
+        usort(
+            $comments,
+            static function (ItemComment $left, ItemComment $right): int {
+                return strcmp($left->getCreatedAt(), $right->getCreatedAt());
+            }
+        );
+
+        return $comments;
+    }
+
+    public function countByItemUri(string $itemUri): int
+    {
+        return count($this->findByItemUri($itemUri));
+    }
+
+    private function mapResource(core_kernel_classes_Resource $resource): ItemComment
+    {
+        return new ItemComment(
+            $resource->getUri(),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_ITEM_URI)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_AUTHOR_ID)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_AUTHOR_LABEL)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_BODY)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_CREATED_AT)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_STATUS))
+                ?: ItemComment::STATUS_ACTIVE
+        );
+    }
+}

--- a/models/classes/Comment/ServiceProvider/ItemCommentServiceProvider.php
+++ b/models/classes/Comment/ServiceProvider/ItemCommentServiceProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment\ServiceProvider;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\ItemCommentService;
+use oat\taoItems\model\Comment\RdfItemCommentAdapter;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+class ItemCommentServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(RdfItemCommentAdapter::class, RdfItemCommentAdapter::class)
+            ->public();
+
+        $services
+            ->set(ItemCommentPersistenceProxy::class, ItemCommentPersistenceProxy::class)
+            ->public();
+
+        $services
+            ->set(ItemCommentService::class, ItemCommentService::class)
+            ->public();
+    }
+}

--- a/models/ontology/itemComment.rdf
+++ b/models/ontology/itemComment.rdf
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<rdf:RDF
+	xml:base="http://www.tao.lu/Ontologies/TAOItem.rdf#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:widget="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#"
+	xmlns:generis="http://www.tao.lu/Ontologies/generis.rdf#"
+>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment">
+        <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#TAOObject"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Item Comment]]></rdfs:label>
+        <rdfs:comment xml:lang="en-US"><![CDATA[Whole-item collaboration comment (not part of ItemContent/QTI)]]></rdfs:comment>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentItemUri">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Item URI]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentAuthorId">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Author ID]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentAuthorLabel">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Author label]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentBody">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Comment body]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentCreatedAt">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Created at]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentStatus">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Status]]></rdfs:label>
+    </rdf:Description>
+
+</rdf:RDF>

--- a/scripts/install/RegisterItemCommentServices.php
+++ b/scripts/install/RegisterItemCommentServices.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\ItemCommentService;
+use oat\taoItems\model\Comment\RdfItemCommentAdapter;
+
+class RegisterItemCommentServices extends InstallAction
+{
+    public function __invoke($params = [])
+    {
+        $serviceManager = $this->getServiceManager();
+
+        $rdfAdapter = new RdfItemCommentAdapter();
+        $serviceManager->propagate($rdfAdapter);
+        $serviceManager->register(RdfItemCommentAdapter::SERVICE_ID, $rdfAdapter);
+
+        $activeAdapter = RdfItemCommentAdapter::SERVICE_ID;
+        if ($serviceManager->has('taoAdvancedSearch/ElasticsearchItemCommentAdapter')) {
+            $activeAdapter = 'taoAdvancedSearch/ElasticsearchItemCommentAdapter';
+        }
+
+        $proxy = new ItemCommentPersistenceProxy([
+            ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER => $activeAdapter,
+        ]);
+        $serviceManager->propagate($proxy);
+        $serviceManager->register(ItemCommentPersistenceProxy::SERVICE_ID, $proxy);
+
+        $service = new ItemCommentService();
+        $serviceManager->propagate($service);
+        $serviceManager->register(ItemCommentService::SERVICE_ID, $service);
+    }
+}

--- a/test/unit/model/Comment/ItemCommentPersistenceProxyTest.php
+++ b/test/unit/model/Comment/ItemCommentPersistenceProxyTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\model\Comment;
+
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\taoItems\model\Comment\ItemComment;
+use oat\taoItems\model\Comment\ItemCommentPersistenceInterface;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\RdfItemCommentAdapter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ItemCommentPersistenceProxyTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    /** @var ItemCommentPersistenceInterface|MockObject */
+    private $adapter;
+
+    private ItemCommentPersistenceProxy $sut;
+
+    protected function setUp(): void
+    {
+        $this->adapter = $this->createMock(ItemCommentPersistenceInterface::class);
+
+        $this->sut = new ItemCommentPersistenceProxy([
+            ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER => 'activeAdapterService',
+        ]);
+        $this->sut->setServiceLocator(
+            $this->getServiceManagerMock([
+                'activeAdapterService' => $this->adapter,
+            ])
+        );
+    }
+
+    public function testDelegatesCreateToActiveAdapter(): void
+    {
+        $comment = new ItemComment(
+            'c1',
+            'item-1',
+            'author',
+            'Author',
+            'body',
+            '2026-08-03T10:00:00+00:00'
+        );
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('create')
+            ->with($comment)
+            ->willReturn($comment);
+
+        $this->assertSame($comment, $this->sut->create($comment));
+    }
+
+    public function testDefaultsToRdfAdapterServiceId(): void
+    {
+        $proxy = new ItemCommentPersistenceProxy();
+        $this->assertSame(
+            RdfItemCommentAdapter::SERVICE_ID,
+            $proxy->getOption(
+                ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER,
+                RdfItemCommentAdapter::SERVICE_ID
+            )
+        );
+    }
+}

--- a/test/unit/model/Comment/ItemCommentServiceTest.php
+++ b/test/unit/model/Comment/ItemCommentServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\model\Comment;
+
+use common_exception_Unauthorized;
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\taoItems\model\Comment\ItemComment;
+use oat\taoItems\model\Comment\ItemCommentPersistenceInterface;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\ItemCommentService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ItemCommentServiceTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    /** @var ItemCommentPersistenceInterface|MockObject */
+    private $persistence;
+
+    /** @var FeatureFlagCheckerInterface|MockObject */
+    private $featureFlagChecker;
+
+    private ItemCommentService $sut;
+
+    protected function setUp(): void
+    {
+        $this->persistence = $this->createMock(ItemCommentPersistenceInterface::class);
+        $this->featureFlagChecker = $this->createMock(FeatureFlagCheckerInterface::class);
+
+        $this->sut = new ItemCommentService();
+        $this->sut->setServiceLocator(
+            $this->getServiceManagerMock([
+                ItemCommentPersistenceProxy::SERVICE_ID => $this->persistence,
+                FeatureFlagChecker::class => $this->featureFlagChecker,
+            ])
+        );
+    }
+
+    public function testListThrowsWhenFeatureFlagDisabled(): void
+    {
+        $this->featureFlagChecker
+            ->method('isEnabled')
+            ->with(FeatureFlagCheckerInterface::FEATURE_FLAG_ITEM_COMMENTS_ENABLED)
+            ->willReturn(false);
+
+        $this->expectException(common_exception_Unauthorized::class);
+        $this->sut->list('http://example.test/item#1');
+    }
+
+    public function testListReturnsCommentsWhenEnabled(): void
+    {
+        $this->featureFlagChecker
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $comment = new ItemComment(
+            'c1',
+            'http://example.test/item#1',
+            'user-1',
+            'Alice',
+            'Hello',
+            '2026-08-03T10:00:00+00:00'
+        );
+
+        $this->persistence
+            ->expects($this->once())
+            ->method('findByItemUri')
+            ->with('http://example.test/item#1')
+            ->willReturn([$comment]);
+
+        $result = $this->sut->list('http://example.test/item#1');
+
+        $this->assertSame(1, $result['count']);
+        $this->assertSame('c1', $result['comments'][0]['id']);
+        $this->assertSame('Hello', $result['comments'][0]['body']);
+    }
+
+    public function testCountRequiresItemUri(): void
+    {
+        $this->featureFlagChecker->method('isEnabled')->willReturn(true);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sut->count('  ');
+    }
+}


### PR DESCRIPTION
## Summary
- Add FF-gated Item Comments API in `taoItems` with RDF default persistence proxy
- Replace persistence adapter with Elasticsearch when `taoAdvancedSearch` is installed
- Author stamped from LTI Session; no item ACL gating in M1

## Test plan
- [ ] `FEATURE_FLAG_ITEM_COMMENTS_ENABLED=true`
- [ ] Without AS: create/list/count via `/taoItems/RestItemComments/*` persists RDF comments
- [ ] With AS installed: proxy active adapter is Elasticsearch
- [ ] Unit tests: `taoItems/test/unit/model/Comment/` and `taoAdvancedSearch/tests/Unit/Comment/`
- [ ] Flag off returns 403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added item comments with author details, timestamps, status, and comment text.
  - Added REST endpoints to list, create, and count comments for an item.
  - Added validation, authentication checks, feature controls, and standardized error responses.
  - Added installation and storage support for item comments.

- **Tests**
  - Added coverage for comment listing, counting, creation delegation, and feature controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->