### PR TITLE
feat: item comments FE client and RestItemComments ACL (NYSED-20)

### DIFF
--- a/actions/class.RestItemComments.php
+++ b/actions/class.RestItemComments.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+use oat\tao\model\http\HttpJsonResponseTrait;
+use oat\taoItems\model\Comment\ItemCommentService;
+
+/**
+ * Item comments REST API (FR1 M1).
+ *
+ * Routes:
+ * - GET  /taoItems/RestItemComments/index?itemUri=
+ * - POST /taoItems/RestItemComments/index  (itemUri, body)
+ * - GET  /taoItems/RestItemComments/count?itemUri=
+ */
+class taoItems_actions_RestItemComments extends tao_actions_CommonModule
+{
+    use HttpJsonResponseTrait;
+
+    public function index(): void
+    {
+        try {
+            if ($this->isGetRequest()) {
+                $itemUri = (string) ($this->getPsrRequest()->getQueryParams()['itemUri'] ?? '');
+                $this->setSuccessJsonResponse($this->getItemCommentService()->list($itemUri));
+
+                return;
+            }
+
+            if ($this->isPostRequest()) {
+                $payload = $this->getRequestPayload();
+                $itemUri = (string) ($payload['itemUri'] ?? '');
+                $body = (string) ($payload['body'] ?? '');
+                $comment = $this->getItemCommentService()->create($itemUri, $body);
+                $this->setSuccessJsonResponse($comment->toArray(), 201);
+
+                return;
+            }
+
+            $this->setErrorJsonResponse('Method not allowed', 405, [], 405);
+        } catch (common_exception_Unauthorized $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 403, [], 403);
+        } catch (InvalidArgumentException $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 412, [], 412);
+        } catch (Throwable $exception) {
+            $this->logError($exception->getMessage());
+            $this->setErrorJsonResponse('Unable to process item comments request', 500, [], 500);
+        }
+    }
+
+    public function count(): void
+    {
+        try {
+            if (!$this->isGetRequest()) {
+                $this->setErrorJsonResponse('Method not allowed', 405, [], 405);
+
+                return;
+            }
+
+            $itemUri = (string) ($this->getPsrRequest()->getQueryParams()['itemUri'] ?? '');
+            $this->setSuccessJsonResponse([
+                'count' => $this->getItemCommentService()->count($itemUri),
+            ]);
+        } catch (common_exception_Unauthorized $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 403, [], 403);
+        } catch (InvalidArgumentException $exception) {
+            $this->setErrorJsonResponse($exception->getMessage(), 412, [], 412);
+        } catch (Throwable $exception) {
+            $this->logError($exception->getMessage());
+            $this->setErrorJsonResponse('Unable to process item comments count', 500, [], 500);
+        }
+    }
+
+    private function getRequestPayload(): array
+    {
+        $parsed = $this->getPsrRequest()->getParsedBody();
+        if (is_array($parsed) && $parsed !== []) {
+            return $parsed;
+        }
+
+        $raw = (string) $this->getPsrRequest()->getBody();
+        if ($raw === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function isGetRequest(): bool
+    {
+        return strtoupper($this->getPsrRequest()->getMethod()) === 'GET';
+    }
+
+    private function isPostRequest(): bool
+    {
+        return strtoupper($this->getPsrRequest()->getMethod()) === 'POST';
+    }
+
+    private function getItemCommentService(): ItemCommentService
+    {
+        return $this->getServiceLocator()->get(ItemCommentService::SERVICE_ID);
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -95,7 +95,22 @@ return [
         [
             AccessRule::GRANT,
             TaoItemsRoles::ITEM_AUTHOR_ABSTRACT,
-            'taoItems_actions_RestItemComments',
+            ['ext' => 'taoItems', 'mod' => 'RestItemComments'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_MANAGER,
+            ['ext' => 'taoItems', 'mod' => 'RestItemComments'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_CONTENT_CREATOR,
+            ['ext' => 'taoItems', 'mod' => 'RestItemComments'],
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_VIEWER,
+            ['ext' => 'taoItems', 'mod' => 'RestItemComments'],
         ],
         [
             AccessRule::GRANT,

--- a/manifest.php
+++ b/manifest.php
@@ -32,6 +32,7 @@ use oat\taoItems\model\Translation\ServiceProvider\TranslationServiceProvider;
 use oat\taoItems\model\user\TaoItemsRoles;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\taoItems\model\FrontendAction\FrontendActionServiceProvider;
+use oat\taoItems\model\Comment\ServiceProvider\ItemCommentServiceProvider;
 use oat\taoItems\scripts\install\RegisterNpmPaths;
 use oat\taoItems\model\Copier\CopierServiceProvider;
 use oat\taoItems\scripts\install\CreateItemDirectory;
@@ -39,6 +40,7 @@ use oat\taoItems\scripts\install\SetRolesPermissions;
 use oat\taoItems\scripts\install\RegisterCategoryService;
 use oat\taoItems\scripts\install\RegisterAssetTreeBuilder;
 use oat\taoItems\scripts\install\RegisterItemPreviewerRegistryService;
+use oat\taoItems\scripts\install\RegisterItemCommentServices;
 use oat\taoItems\scripts\install\SetupEventListeners;
 use oat\taoItems\scripts\install\SetupSectionVisibilityFilters;
 
@@ -63,6 +65,7 @@ return [
             __DIR__ . '/models/ontology/taoItemRunner.rdf',
             __DIR__ . '/models/ontology/indexation.rdf',
             __DIR__ . '/models/ontology/category.rdf',
+            __DIR__ . '/models/ontology/itemComment.rdf',
         ],
         'php' => [
             CreateItemDirectory::class,
@@ -72,7 +75,8 @@ return [
             RegisterAssetTreeBuilder::class,
             SetRolesPermissions::class,
             SetupEventListeners::class,
-            SetupSectionVisibilityFilters::class
+            SetupSectionVisibilityFilters::class,
+            RegisterItemCommentServices::class,
         ],
     ],
     'update' => taoItems_scripts_update_Updater::class,
@@ -87,6 +91,11 @@ return [
             AccessRule::GRANT,
             TaoItemsRoles::ITEM_AUTHOR_ABSTRACT,
             'taoItems_actions_ItemContent',
+        ],
+        [
+            AccessRule::GRANT,
+            TaoItemsRoles::ITEM_AUTHOR_ABSTRACT,
+            'taoItems_actions_RestItemComments',
         ],
         [
             AccessRule::GRANT,
@@ -272,5 +281,6 @@ return [
         TranslationServiceProvider::class,
         FormServiceProvider::class,
         FrontendActionServiceProvider::class,
+        ItemCommentServiceProvider::class,
     ],
 ];

--- a/migrations/Version202608031745002141_taoItems.php
+++ b/migrations/Version202608031745002141_taoItems.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoItems\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\tao\scripts\update\OntologyUpdater;
+use oat\taoItems\scripts\install\RegisterItemCommentServices;
+
+/**
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202608031745002141_taoItems extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Register Item Comments RDF ontology and persistence services (NYSED-19)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        OntologyUpdater::syncModels();
+
+        $script = new RegisterItemCommentServices();
+        $script->setServiceLocator($this->getServiceLocator());
+        $script([]);
+
+        $this->addReport(Report::createSuccess('Item Comment services registered with RDF default adapter'));
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Intentionally left empty: ontology and services remain for forward compatibility.
+    }
+}

--- a/migrations/Version202608040542122141_taoItems.php
+++ b/migrations/Version202608040542122141_taoItems.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace oat\taoItems\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use oat\oatbox\reporting\Report;
+use oat\tao\model\accessControl\func\AccessRule;
+use oat\tao\model\accessControl\func\AclProxy;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoItems\model\user\TaoItemsRoles;
+
+/**
+ * phpcs:disable Squiz.Classes.ValidClassName
+ */
+final class Version202608040542122141_taoItems extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Grant ACL for RestItemComments module to authoring roles (NYSED-20)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        foreach ($this->getRules() as $rule) {
+            AclProxy::applyRule($rule);
+        }
+
+        $this->addReport(Report::createSuccess('Applied RestItemComments ACL rules'));
+    }
+
+    public function down(Schema $schema): void
+    {
+        foreach ($this->getRules() as $rule) {
+            AclProxy::revokeRule($rule);
+        }
+
+        $this->addReport(Report::createSuccess('Revoked RestItemComments ACL rules'));
+    }
+
+    /**
+     * @return AccessRule[]
+     */
+    private function getRules(): array
+    {
+        // Prefer ext/mod mask — string class masks can fail silently if class_exists is false
+        // during applyRule evaluation.
+        $mask = [
+            'ext' => 'taoItems',
+            'mod' => 'RestItemComments',
+        ];
+
+        return [
+            new AccessRule(AccessRule::GRANT, TaoItemsRoles::ITEM_AUTHOR_ABSTRACT, $mask),
+            new AccessRule(AccessRule::GRANT, TaoItemsRoles::ITEM_MANAGER, $mask),
+            new AccessRule(AccessRule::GRANT, TaoItemsRoles::ITEM_CONTENT_CREATOR, $mask),
+            new AccessRule(AccessRule::GRANT, TaoItemsRoles::ITEM_AUTHOR, $mask),
+            new AccessRule(AccessRule::GRANT, TaoItemsRoles::ITEM_VIEWER, $mask),
+            new AccessRule(
+                AccessRule::GRANT,
+                'http://www.tao.lu/Ontologies/TAO.rdf#GlobalManagerRole',
+                $mask
+            ),
+        ];
+    }
+}

--- a/models/classes/Comment/ItemComment.php
+++ b/models/classes/Comment/ItemComment.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+final class ItemComment
+{
+    public const STATUS_ACTIVE = 'active';
+
+    private string $id;
+    private string $itemUri;
+    private string $authorId;
+    private string $authorLabel;
+    private string $body;
+    private string $createdAt;
+    private string $status;
+
+    public function __construct(
+        string $id,
+        string $itemUri,
+        string $authorId,
+        string $authorLabel,
+        string $body,
+        string $createdAt,
+        string $status = self::STATUS_ACTIVE
+    ) {
+        $this->id = $id;
+        $this->itemUri = $itemUri;
+        $this->authorId = $authorId;
+        $this->authorLabel = $authorLabel;
+        $this->body = $body;
+        $this->createdAt = $createdAt;
+        $this->status = $status;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getItemUri(): string
+    {
+        return $this->itemUri;
+    }
+
+    public function getAuthorId(): string
+    {
+        return $this->authorId;
+    }
+
+    public function getAuthorLabel(): string
+    {
+        return $this->authorLabel;
+    }
+
+    public function getBody(): string
+    {
+        return $this->body;
+    }
+
+    public function getCreatedAt(): string
+    {
+        return $this->createdAt;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'itemUri' => $this->itemUri,
+            'authorId' => $this->authorId,
+            'authorLabel' => $this->authorLabel,
+            'body' => $this->body,
+            'createdAt' => $this->createdAt,
+            'status' => $this->status,
+        ];
+    }
+}

--- a/models/classes/Comment/ItemCommentOntology.php
+++ b/models/classes/Comment/ItemCommentOntology.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+final class ItemCommentOntology
+{
+    public const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment';
+    public const PROPERTY_ITEM_URI = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentItemUri';
+    public const PROPERTY_AUTHOR_ID = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentAuthorId';
+    public const PROPERTY_AUTHOR_LABEL = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentAuthorLabel';
+    public const PROPERTY_BODY = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentBody';
+    public const PROPERTY_CREATED_AT = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentCreatedAt';
+    public const PROPERTY_STATUS = 'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentStatus';
+}

--- a/models/classes/Comment/ItemCommentPersistenceInterface.php
+++ b/models/classes/Comment/ItemCommentPersistenceInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+interface ItemCommentPersistenceInterface
+{
+    public function create(ItemComment $comment): ItemComment;
+
+    /**
+     * @return ItemComment[]
+     */
+    public function findByItemUri(string $itemUri): array;
+
+    public function countByItemUri(string $itemUri): int;
+}

--- a/models/classes/Comment/ItemCommentPersistenceProxy.php
+++ b/models/classes/Comment/ItemCommentPersistenceProxy.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+use oat\oatbox\service\ConfigurableService;
+
+/**
+ * Delegates to the active adapter (RDF by default; Elasticsearch when AS replaces it).
+ */
+class ItemCommentPersistenceProxy extends ConfigurableService implements ItemCommentPersistenceInterface
+{
+    public const SERVICE_ID = 'taoItems/ItemCommentPersistence';
+    public const OPTION_ACTIVE_ADAPTER = 'activeAdapter';
+
+    public function create(ItemComment $comment): ItemComment
+    {
+        return $this->getActiveAdapter()->create($comment);
+    }
+
+    public function findByItemUri(string $itemUri): array
+    {
+        return $this->getActiveAdapter()->findByItemUri($itemUri);
+    }
+
+    public function countByItemUri(string $itemUri): int
+    {
+        return $this->getActiveAdapter()->countByItemUri($itemUri);
+    }
+
+    private function getActiveAdapter(): ItemCommentPersistenceInterface
+    {
+        $adapterId = $this->getOption(
+            self::OPTION_ACTIVE_ADAPTER,
+            RdfItemCommentAdapter::SERVICE_ID
+        );
+
+        /** @var ItemCommentPersistenceInterface $adapter */
+        $adapter = $this->getServiceLocator()->get($adapterId);
+
+        return $adapter;
+    }
+}

--- a/models/classes/Comment/ItemCommentService.php
+++ b/models/classes/Comment/ItemCommentService.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+use common_exception_Unauthorized;
+use common_session_SessionManager;
+use DateTimeImmutable;
+use DateTimeZone;
+use InvalidArgumentException;
+use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use Ramsey\Uuid\Uuid;
+
+class ItemCommentService extends ConfigurableService
+{
+    public const SERVICE_ID = 'taoItems/ItemCommentService';
+
+    /**
+     * @return array{comments: array<int, array<string, string>>, count: int}
+     */
+    public function list(string $itemUri): array
+    {
+        $this->assertFeatureEnabled();
+        $itemUri = $this->assertItemUri($itemUri);
+
+        $comments = $this->getPersistence()->findByItemUri($itemUri);
+
+        return [
+            'comments' => array_map(
+                static function (ItemComment $comment): array {
+                    return $comment->toArray();
+                },
+                $comments
+            ),
+            'count' => count($comments),
+        ];
+    }
+
+    public function count(string $itemUri): int
+    {
+        $this->assertFeatureEnabled();
+        $itemUri = $this->assertItemUri($itemUri);
+
+        return $this->getPersistence()->countByItemUri($itemUri);
+    }
+
+    public function create(string $itemUri, string $body): ItemComment
+    {
+        $this->assertFeatureEnabled();
+        $itemUri = $this->assertItemUri($itemUri);
+        $body = $this->assertBody($body);
+
+        $session = common_session_SessionManager::getSession();
+        if ($session === null || $session->getUser() === null) {
+            throw new common_exception_Unauthorized('Authenticated session required to create item comments');
+        }
+
+        $comment = new ItemComment(
+            Uuid::uuid4()->toString(),
+            $itemUri,
+            (string) $session->getUser()->getIdentifier(),
+            (string) $session->getUserLabel(),
+            $body,
+            (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format(DATE_ATOM),
+            ItemComment::STATUS_ACTIVE
+        );
+
+        return $this->getPersistence()->create($comment);
+    }
+
+    private function getPersistence(): ItemCommentPersistenceInterface
+    {
+        return $this->getServiceLocator()->get(ItemCommentPersistenceProxy::SERVICE_ID);
+    }
+
+    private function getFeatureFlagChecker(): FeatureFlagCheckerInterface
+    {
+        return $this->getServiceLocator()->get(FeatureFlagChecker::class);
+    }
+
+    private function assertFeatureEnabled(): void
+    {
+        if (
+            !$this->getFeatureFlagChecker()->isEnabled(
+                FeatureFlagCheckerInterface::FEATURE_FLAG_ITEM_COMMENTS_ENABLED
+            )
+        ) {
+            throw new common_exception_Unauthorized('Item comments feature is disabled');
+        }
+    }
+
+    private function assertItemUri(string $itemUri): string
+    {
+        $itemUri = trim($itemUri);
+        if ($itemUri === '') {
+            throw new InvalidArgumentException('itemUri is required');
+        }
+
+        return $itemUri;
+    }
+
+    private function assertBody(string $body): string
+    {
+        $body = trim($body);
+        if ($body === '') {
+            throw new InvalidArgumentException('Comment body must not be empty');
+        }
+
+        return $body;
+    }
+}

--- a/models/classes/Comment/RdfItemCommentAdapter.php
+++ b/models/classes/Comment/RdfItemCommentAdapter.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment;
+
+use core_kernel_classes_Resource;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+
+class RdfItemCommentAdapter extends ConfigurableService implements ItemCommentPersistenceInterface
+{
+    use OntologyAwareTrait;
+
+    public const SERVICE_ID = 'taoItems/RdfItemCommentAdapter';
+
+    public function create(ItemComment $comment): ItemComment
+    {
+        $resource = $this->getClass(ItemCommentOntology::CLASS_URI)->createInstanceWithProperties([
+            ItemCommentOntology::PROPERTY_ITEM_URI => $comment->getItemUri(),
+            ItemCommentOntology::PROPERTY_AUTHOR_ID => $comment->getAuthorId(),
+            ItemCommentOntology::PROPERTY_AUTHOR_LABEL => $comment->getAuthorLabel(),
+            ItemCommentOntology::PROPERTY_BODY => $comment->getBody(),
+            ItemCommentOntology::PROPERTY_CREATED_AT => $comment->getCreatedAt(),
+            ItemCommentOntology::PROPERTY_STATUS => $comment->getStatus(),
+        ]);
+
+        return new ItemComment(
+            $resource->getUri(),
+            $comment->getItemUri(),
+            $comment->getAuthorId(),
+            $comment->getAuthorLabel(),
+            $comment->getBody(),
+            $comment->getCreatedAt(),
+            $comment->getStatus()
+        );
+    }
+
+    public function findByItemUri(string $itemUri): array
+    {
+        $resources = $this->getClass(ItemCommentOntology::CLASS_URI)->searchInstances(
+            [
+                ItemCommentOntology::PROPERTY_ITEM_URI => $itemUri,
+            ],
+            [
+                'recursive' => false,
+                'like' => false,
+            ]
+        );
+
+        $comments = [];
+        foreach ($resources as $resource) {
+            $comments[] = $this->mapResource($resource);
+        }
+
+        usort(
+            $comments,
+            static function (ItemComment $left, ItemComment $right): int {
+                return strcmp($left->getCreatedAt(), $right->getCreatedAt());
+            }
+        );
+
+        return $comments;
+    }
+
+    public function countByItemUri(string $itemUri): int
+    {
+        return count($this->findByItemUri($itemUri));
+    }
+
+    private function mapResource(core_kernel_classes_Resource $resource): ItemComment
+    {
+        return new ItemComment(
+            $resource->getUri(),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_ITEM_URI)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_AUTHOR_ID)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_AUTHOR_LABEL)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_BODY)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_CREATED_AT)),
+            (string) $resource->getOnePropertyValue($this->getProperty(ItemCommentOntology::PROPERTY_STATUS))
+                ?: ItemComment::STATUS_ACTIVE
+        );
+    }
+}

--- a/models/classes/Comment/ServiceProvider/ItemCommentServiceProvider.php
+++ b/models/classes/Comment/ServiceProvider/ItemCommentServiceProvider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\model\Comment\ServiceProvider;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\ItemCommentService;
+use oat\taoItems\model\Comment\RdfItemCommentAdapter;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+class ItemCommentServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(RdfItemCommentAdapter::class, RdfItemCommentAdapter::class)
+            ->public();
+
+        $services
+            ->set(ItemCommentPersistenceProxy::class, ItemCommentPersistenceProxy::class)
+            ->public();
+
+        $services
+            ->set(ItemCommentService::class, ItemCommentService::class)
+            ->public();
+    }
+}

--- a/models/ontology/itemComment.rdf
+++ b/models/ontology/itemComment.rdf
@@ -1,0 +1,58 @@
+<?xml version="1.0"?>
+<rdf:RDF
+	xml:base="http://www.tao.lu/Ontologies/TAOItem.rdf#"
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:widget="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#"
+	xmlns:generis="http://www.tao.lu/Ontologies/generis.rdf#"
+>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment">
+        <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/TAO.rdf#TAOObject"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Item Comment]]></rdfs:label>
+        <rdfs:comment xml:lang="en-US"><![CDATA[Whole-item collaboration comment (not part of ItemContent/QTI)]]></rdfs:comment>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentItemUri">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Item URI]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentAuthorId">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Author ID]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentAuthorLabel">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Author label]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentBody">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Comment body]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentCreatedAt">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Created at]]></rdfs:label>
+    </rdf:Description>
+
+    <rdf:Description rdf:about="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemCommentStatus">
+        <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+        <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/TAOItem.rdf#ItemComment"/>
+        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+        <rdfs:label xml:lang="en-US"><![CDATA[Status]]></rdfs:label>
+    </rdf:Description>
+
+</rdf:RDF>

--- a/scripts/install/RegisterItemCommentServices.php
+++ b/scripts/install/RegisterItemCommentServices.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\ItemCommentService;
+use oat\taoItems\model\Comment\RdfItemCommentAdapter;
+
+class RegisterItemCommentServices extends InstallAction
+{
+    public function __invoke($params = [])
+    {
+        $serviceManager = $this->getServiceManager();
+
+        $rdfAdapter = new RdfItemCommentAdapter();
+        $serviceManager->propagate($rdfAdapter);
+        $serviceManager->register(RdfItemCommentAdapter::SERVICE_ID, $rdfAdapter);
+
+        $activeAdapter = RdfItemCommentAdapter::SERVICE_ID;
+        if ($serviceManager->has('taoAdvancedSearch/ElasticsearchItemCommentAdapter')) {
+            $activeAdapter = 'taoAdvancedSearch/ElasticsearchItemCommentAdapter';
+        }
+
+        $proxy = new ItemCommentPersistenceProxy([
+            ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER => $activeAdapter,
+        ]);
+        $serviceManager->propagate($proxy);
+        $serviceManager->register(ItemCommentPersistenceProxy::SERVICE_ID, $proxy);
+
+        $service = new ItemCommentService();
+        $serviceManager->propagate($service);
+        $serviceManager->register(ItemCommentService::SERVICE_ID, $service);
+    }
+}

--- a/test/unit/model/Comment/ItemCommentPersistenceProxyTest.php
+++ b/test/unit/model/Comment/ItemCommentPersistenceProxyTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\model\Comment;
+
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\taoItems\model\Comment\ItemComment;
+use oat\taoItems\model\Comment\ItemCommentPersistenceInterface;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\RdfItemCommentAdapter;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ItemCommentPersistenceProxyTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    /** @var ItemCommentPersistenceInterface|MockObject */
+    private $adapter;
+
+    private ItemCommentPersistenceProxy $sut;
+
+    protected function setUp(): void
+    {
+        $this->adapter = $this->createMock(ItemCommentPersistenceInterface::class);
+
+        $this->sut = new ItemCommentPersistenceProxy([
+            ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER => 'activeAdapterService',
+        ]);
+        $this->sut->setServiceLocator(
+            $this->getServiceManagerMock([
+                'activeAdapterService' => $this->adapter,
+            ])
+        );
+    }
+
+    public function testDelegatesCreateToActiveAdapter(): void
+    {
+        $comment = new ItemComment(
+            'c1',
+            'item-1',
+            'author',
+            'Author',
+            'body',
+            '2026-08-03T10:00:00+00:00'
+        );
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('create')
+            ->with($comment)
+            ->willReturn($comment);
+
+        $this->assertSame($comment, $this->sut->create($comment));
+    }
+
+    public function testDefaultsToRdfAdapterServiceId(): void
+    {
+        $proxy = new ItemCommentPersistenceProxy();
+        $this->assertSame(
+            RdfItemCommentAdapter::SERVICE_ID,
+            $proxy->getOption(
+                ItemCommentPersistenceProxy::OPTION_ACTIVE_ADAPTER,
+                RdfItemCommentAdapter::SERVICE_ID
+            )
+        );
+    }
+}

--- a/test/unit/model/Comment/ItemCommentServiceTest.php
+++ b/test/unit/model/Comment/ItemCommentServiceTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoItems\test\unit\model\Comment;
+
+use common_exception_Unauthorized;
+use oat\generis\test\ServiceManagerMockTrait;
+use oat\tao\model\featureFlag\FeatureFlagChecker;
+use oat\tao\model\featureFlag\FeatureFlagCheckerInterface;
+use oat\taoItems\model\Comment\ItemComment;
+use oat\taoItems\model\Comment\ItemCommentPersistenceInterface;
+use oat\taoItems\model\Comment\ItemCommentPersistenceProxy;
+use oat\taoItems\model\Comment\ItemCommentService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ItemCommentServiceTest extends TestCase
+{
+    use ServiceManagerMockTrait;
+
+    /** @var ItemCommentPersistenceInterface|MockObject */
+    private $persistence;
+
+    /** @var FeatureFlagCheckerInterface|MockObject */
+    private $featureFlagChecker;
+
+    private ItemCommentService $sut;
+
+    protected function setUp(): void
+    {
+        $this->persistence = $this->createMock(ItemCommentPersistenceInterface::class);
+        $this->featureFlagChecker = $this->createMock(FeatureFlagCheckerInterface::class);
+
+        $this->sut = new ItemCommentService();
+        $this->sut->setServiceLocator(
+            $this->getServiceManagerMock([
+                ItemCommentPersistenceProxy::SERVICE_ID => $this->persistence,
+                FeatureFlagChecker::class => $this->featureFlagChecker,
+            ])
+        );
+    }
+
+    public function testListThrowsWhenFeatureFlagDisabled(): void
+    {
+        $this->featureFlagChecker
+            ->method('isEnabled')
+            ->with(FeatureFlagCheckerInterface::FEATURE_FLAG_ITEM_COMMENTS_ENABLED)
+            ->willReturn(false);
+
+        $this->expectException(common_exception_Unauthorized::class);
+        $this->sut->list('http://example.test/item#1');
+    }
+
+    public function testListReturnsCommentsWhenEnabled(): void
+    {
+        $this->featureFlagChecker
+            ->method('isEnabled')
+            ->willReturn(true);
+
+        $comment = new ItemComment(
+            'c1',
+            'http://example.test/item#1',
+            'user-1',
+            'Alice',
+            'Hello',
+            '2026-08-03T10:00:00+00:00'
+        );
+
+        $this->persistence
+            ->expects($this->once())
+            ->method('findByItemUri')
+            ->with('http://example.test/item#1')
+            ->willReturn([$comment]);
+
+        $result = $this->sut->list('http://example.test/item#1');
+
+        $this->assertSame(1, $result['count']);
+        $this->assertSame('c1', $result['comments'][0]['id']);
+        $this->assertSame('Hello', $result['comments'][0]['body']);
+    }
+
+    public function testCountRequiresItemUri(): void
+    {
+        $this->featureFlagChecker->method('isEnabled')->willReturn(true);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->sut->count('  ');
+    }
+}

--- a/views/js/comments/itemCommentsStore.js
+++ b/views/js/comments/itemCommentsStore.js
@@ -1,0 +1,198 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+define(['lodash', 'core/eventifier', 'taoItems/services/itemComments'], function (
+    _,
+    eventifier,
+    itemCommentsApi
+) {
+    'use strict';
+
+    /**
+     * In-memory Item Comments session store (FR1 M1).
+     *
+     * @param {object} config
+     * @param {string} config.itemUri
+     * @param {object} [config.api]
+     * @returns {object}
+     */
+    function itemCommentsStoreFactory(config) {
+        const api = (config && config.api) || itemCommentsApi;
+        let itemUri = (config && config.itemUri) || '';
+        let comments = [];
+        let count = 0;
+        let draft = '';
+        let loaded = false;
+        let loading = false;
+        let submitting = false;
+        let loadError = null;
+        let submitError = null;
+
+        const store = {
+            getItemUri() {
+                return itemUri;
+            },
+
+            setItemUri(nextItemUri) {
+                if (nextItemUri === itemUri) {
+                    return this;
+                }
+                itemUri = nextItemUri || '';
+                comments = [];
+                count = 0;
+                draft = '';
+                loaded = false;
+                loading = false;
+                submitting = false;
+                loadError = null;
+                submitError = null;
+                this.trigger('reset');
+                return this;
+            },
+
+            getComments() {
+                return comments.slice();
+            },
+
+            getCount() {
+                return count;
+            },
+
+            setDraft(text) {
+                draft = typeof text === 'string' ? text : '';
+                submitError = null;
+                this.trigger('draftchange', draft);
+                return this;
+            },
+
+            getDraft() {
+                return draft;
+            },
+
+            hasDirtyDraft() {
+                return /\S/.test(draft);
+            },
+
+            clearDraft() {
+                return this.setDraft('');
+            },
+
+            isLoading() {
+                return loading;
+            },
+
+            isSubmitting() {
+                return submitting;
+            },
+
+            getLoadError() {
+                return loadError;
+            },
+
+            getSubmitError() {
+                return submitError;
+            },
+
+            load(options) {
+                const force = !!(options && options.force);
+                if (!itemUri) {
+                    return Promise.reject(new Error('itemUri is required'));
+                }
+                if (loaded && !force) {
+                    return Promise.resolve(this);
+                }
+                if (loading) {
+                    return Promise.resolve(this);
+                }
+
+                loading = true;
+                loadError = null;
+                this.trigger('loading');
+
+                return api
+                    .list(itemUri)
+                    .then(data => {
+                        comments = (data && data.comments) || [];
+                        count = typeof (data && data.count) === 'number' ? data.count : comments.length;
+                        loaded = true;
+                        loading = false;
+                        this.trigger('loaded', comments.slice(), count);
+                        this.trigger('countchange', count);
+                        return this;
+                    })
+                    .catch(error => {
+                        loading = false;
+                        loadError = error;
+                        this.trigger('error', error);
+                        throw error;
+                    });
+            },
+
+            submit() {
+                if (!itemUri) {
+                    return Promise.reject(new Error('itemUri is required'));
+                }
+                const body = draft.trim();
+                if (!body) {
+                    return Promise.reject(new Error('Comment body must not be empty'));
+                }
+                if (submitting) {
+                    return Promise.resolve(this);
+                }
+
+                submitting = true;
+                submitError = null;
+                this.trigger('submitting');
+
+                return api
+                    .create(itemUri, body)
+                    .then(comment => {
+                        comments = comments.concat([comment]);
+                        count += 1;
+                        submitting = false;
+                        this.clearDraft();
+                        this.trigger('submitted', comment);
+                        this.trigger('countchange', count);
+                        return this;
+                    })
+                    .catch(error => {
+                        submitting = false;
+                        submitError = error;
+                        this.trigger('submitFailed', error);
+                        throw error;
+                    });
+            },
+
+            reset() {
+                comments = [];
+                count = 0;
+                draft = '';
+                loaded = false;
+                loading = false;
+                submitting = false;
+                loadError = null;
+                submitError = null;
+                this.trigger('reset');
+                return this;
+            }
+        };
+
+        return eventifier(store);
+    }
+
+    return itemCommentsStoreFactory;
+});

--- a/views/js/services/itemComments.js
+++ b/views/js/services/itemComments.js
@@ -1,0 +1,84 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+define(['core/request', 'util/url'], function (request, urlUtil) {
+    'use strict';
+
+    /**
+     * @typedef {object} ItemComment
+     * @property {string} id
+     * @property {string} itemUri
+     * @property {string} authorId
+     * @property {string} authorLabel
+     * @property {string} body
+     * @property {string} createdAt
+     * @property {string} status
+     */
+
+    /**
+     * @typedef {object} ItemCommentList
+     * @property {ItemComment[]} comments
+     * @property {number} count
+     */
+
+    /**
+     * HTTP client for Item Comments REST API (FR1 M1).
+     * @returns {object}
+     */
+    return {
+        /**
+         * Lists comments for an item (oldest → newest).
+         * @param {string} itemUri
+         * @returns {Promise<ItemCommentList>}
+         */
+        list(itemUri) {
+            return request({
+                url: urlUtil.route('index', 'RestItemComments', 'taoItems', { itemUri }),
+                method: 'GET',
+                noToken: true
+            }).then(response => response.data);
+        },
+
+        /**
+         * Creates a comment for an item.
+         * @param {string} itemUri
+         * @param {string} body
+         * @returns {Promise<ItemComment>}
+         */
+        create(itemUri, body) {
+            return request({
+                url: urlUtil.route('index', 'RestItemComments', 'taoItems'),
+                method: 'POST',
+                data: { itemUri, body },
+                noToken: true
+            }).then(response => response.data);
+        },
+
+        /**
+         * Returns the visible comment count for an item.
+         * @param {string} itemUri
+         * @returns {Promise<{count: number}>}
+         */
+        count(itemUri) {
+            return request({
+                url: urlUtil.route('count', 'RestItemComments', 'taoItems', { itemUri }),
+                method: 'GET',
+                noToken: true
+            }).then(response => response.data);
+        }
+    };
+});

--- a/views/js/test/comments/itemCommentsStore/test.html
+++ b/views/js/test/comments/itemCommentsStore/test.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Item Comments Store</title>
+        <base href="../../../../../../tao/views/" />
+        <link rel="stylesheet" type="text/css" href="js/lib/qunit/qunit.css">
+        <script type="text/javascript" src="js/lib/qunit/qunit.js"></script>
+        <script type="text/javascript" src="js/lib/require.js"></script>
+        <script type="text/javascript">
+            QUnit.config.autostart = false;
+            require(['/tao/ClientConfig/config'], function () {
+                require(['taoItems/test/comments/itemCommentsStore/test'], function () {
+                    QUnit.start();
+                });
+            });
+        </script>
+    </head>
+    <body>
+        <div id="qunit"></div>
+        <div id="qunit-fixture"></div>
+    </body>
+</html>

--- a/views/js/test/comments/itemCommentsStore/test.js
+++ b/views/js/test/comments/itemCommentsStore/test.js
@@ -1,0 +1,207 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+define(['taoItems/comments/itemCommentsStore'], function (itemCommentsStoreFactory) {
+    'use strict';
+
+    QUnit.module('API');
+
+    QUnit.test('factory', function (assert) {
+        assert.expect(3);
+        assert.equal(typeof itemCommentsStoreFactory, 'function', 'module exposes a factory');
+        assert.equal(typeof itemCommentsStoreFactory({ itemUri: 'i1' }), 'object', 'factory returns an object');
+        assert.notStrictEqual(
+            itemCommentsStoreFactory({ itemUri: 'i1' }),
+            itemCommentsStoreFactory({ itemUri: 'i1' }),
+            'factory returns a new instance'
+        );
+    });
+
+    QUnit.module('draft');
+
+    QUnit.test('dirty draft detection', function (assert) {
+        const store = itemCommentsStoreFactory({ itemUri: 'item://1' });
+        assert.expect(4);
+        assert.equal(store.hasDirtyDraft(), false, 'empty draft is not dirty');
+        store.setDraft('   ');
+        assert.equal(store.hasDirtyDraft(), false, 'whitespace-only draft is not dirty');
+        store.setDraft(' hello ');
+        assert.equal(store.hasDirtyDraft(), true, 'non-whitespace draft is dirty');
+        store.clearDraft();
+        assert.equal(store.hasDirtyDraft(), false, 'cleared draft is not dirty');
+    });
+
+    QUnit.module('load / submit');
+
+    QUnit.test('load maps comments and count', function (assert) {
+        const ready = assert.async();
+        const comments = [
+            {
+                id: 'c1',
+                itemUri: 'item://1',
+                authorId: 'u1',
+                authorLabel: 'Ada',
+                body: 'First',
+                createdAt: '2026-07-27T09:12:00Z',
+                status: 'active'
+            }
+        ];
+        const store = itemCommentsStoreFactory({
+            itemUri: 'item://1',
+            api: {
+                list() {
+                    return Promise.resolve({ comments, count: 1 });
+                },
+                create() {
+                    return Promise.reject(new Error('unused'));
+                }
+            }
+        });
+
+        assert.expect(3);
+        store.load().then(function () {
+            assert.deepEqual(store.getComments(), comments, 'comments loaded');
+            assert.equal(store.getCount(), 1, 'count loaded');
+            return store.load();
+        }).then(function () {
+            assert.equal(store.getCount(), 1, 'cached load does not refetch');
+            ready();
+        }).catch(function (err) {
+            assert.ok(false, err.message);
+            ready();
+        });
+    });
+
+    QUnit.test('submit appends comment and clears draft', function (assert) {
+        const ready = assert.async();
+        const created = {
+            id: 'c2',
+            itemUri: 'item://1',
+            authorId: 'u2',
+            authorLabel: 'Grace',
+            body: 'New note',
+            createdAt: '2026-07-27T10:00:00Z',
+            status: 'active'
+        };
+        const store = itemCommentsStoreFactory({
+            itemUri: 'item://1',
+            api: {
+                list() {
+                    return Promise.resolve({ comments: [], count: 0 });
+                },
+                create(itemUri, body) {
+                    assert.equal(itemUri, 'item://1', 'create receives itemUri');
+                    assert.equal(body, 'New note', 'create receives trimmed body');
+                    return Promise.resolve(created);
+                }
+            }
+        });
+
+        assert.expect(6);
+        store
+            .load()
+            .then(function () {
+                store.setDraft('  New note  ');
+                return store.submit();
+            })
+            .then(function () {
+                assert.equal(store.getComments().length, 1, 'comment appended');
+                assert.equal(store.getCount(), 1, 'count incremented');
+                assert.equal(store.getDraft(), '', 'draft cleared');
+                assert.equal(store.hasDirtyDraft(), false, 'draft not dirty');
+                ready();
+            })
+            .catch(function (err) {
+                assert.ok(false, err.message);
+                ready();
+            });
+    });
+
+    QUnit.test('submit failure keeps draft', function (assert) {
+        const ready = assert.async();
+        const store = itemCommentsStoreFactory({
+            itemUri: 'item://1',
+            api: {
+                list() {
+                    return Promise.resolve({ comments: [], count: 0 });
+                },
+                create() {
+                    return Promise.reject(new Error('boom'));
+                }
+            }
+        });
+
+        assert.expect(3);
+        store.setDraft('keep me');
+        store
+            .submit()
+            .then(function () {
+                assert.ok(false, 'should reject');
+                ready();
+            })
+            .catch(function () {
+                assert.equal(store.getDraft(), 'keep me', 'draft retained');
+                assert.equal(store.getCount(), 0, 'count unchanged');
+                assert.equal(store.getComments().length, 0, 'no comment appended');
+                ready();
+            });
+    });
+
+    QUnit.test('setItemUri clears draft and cache', function (assert) {
+        const store = itemCommentsStoreFactory({
+            itemUri: 'item://1',
+            api: {
+                list() {
+                    return Promise.resolve({
+                        comments: [
+                            {
+                                id: 'c1',
+                                itemUri: 'item://1',
+                                authorId: 'u1',
+                                authorLabel: 'Ada',
+                                body: 'A',
+                                createdAt: '2026-07-27T09:12:00Z',
+                                status: 'active'
+                            }
+                        ],
+                        count: 1
+                    });
+                },
+                create() {
+                    return Promise.reject(new Error('unused'));
+                }
+            }
+        });
+        const ready = assert.async();
+
+        assert.expect(3);
+        store
+            .load()
+            .then(function () {
+                store.setDraft('pending');
+                store.setItemUri('item://2');
+                assert.equal(store.getDraft(), '', 'draft cleared on URI change');
+                assert.equal(store.getCount(), 0, 'count reset');
+                assert.deepEqual(store.getComments(), [], 'comments reset');
+                ready();
+            })
+            .catch(function (err) {
+                assert.ok(false, err.message);
+                ready();
+            });
+    });
+});


### PR DESCRIPTION
## Summary
- Add Item Comments FE client (`itemComments` service + store) and QUnit coverage
- Expand RestItemComments ACL grants for authoring roles (manager, content creator, viewer)
- Migration applies the ACL rules on upgrade (NYSED-20)

## Test plan
- [ ] Run migration for taoItems
- [ ] With `FEATURE_FLAG_ITEM_COMMENTS_ENABLED=true`, FE can list/create comments via API
- [ ] Roles ITEM_AUTHOR_ABSTRACT / ITEM_MANAGER / ITEM_CONTENT_CREATOR / ITEM_VIEWER can hit RestItemComments
- [ ] QUnit: `views/js/test/comments/itemCommentsStore/`

Related: NYSED-20, builds on NYSED-19 BE